### PR TITLE
Make test errors visible

### DIFF
--- a/mermaid.go
+++ b/mermaid.go
@@ -55,7 +55,9 @@ func (r *RenderEngine) Render(content string) (string, error) {
 		result string
 	)
 	err := chromedp.Run(r.ctx,
-		chromedp.Evaluate(fmt.Sprintf("mermaid.render('mermaid', `%s`);", content), &result),
+		chromedp.Evaluate(fmt.Sprintf("mermaid.render('mermaid', `%s`).then(({ svg }) => { return svg; });", content), &result, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		}),
 	)
 	return result, err
 }

--- a/mermaid.go
+++ b/mermaid.go
@@ -66,7 +66,7 @@ func (r *RenderEngine) RenderAsPng(content string) ([]byte, *BoxModel, error) {
 		model           *dom.BoxModel
 	)
 	err := chromedp.Run(r.ctx,
-		chromedp.Evaluate(fmt.Sprintf("document.body.innerHTML = mermaid.render('mermaid', `%s`);", content), nil),
+		chromedp.Evaluate(fmt.Sprintf("mermaid.render('mermaid', `%s`).then(({ svg }) => { document.body.innerHTML = svg; });", content), nil),
 		chromedp.Screenshot("#mermaid", &result_in_bytes, chromedp.ByID),
 		chromedp.Dimensions("#mermaid", &model, chromedp.ByID),
 	)

--- a/mermaid.go
+++ b/mermaid.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 )
 
@@ -30,7 +31,7 @@ type RenderEngine struct {
 func NewRenderEngine(ctx context.Context, statements ...string) (*RenderEngine, error) {
 	ctx, cancel := chromedp.NewContext(ctx)
 	var (
-		lib_ready bool
+		lib_ready *runtime.RemoteObject
 	)
 	actions := []chromedp.Action{
 		chromedp.Navigate(DEFAULT_PAGE),
@@ -40,7 +41,7 @@ func NewRenderEngine(ctx context.Context, statements ...string) (*RenderEngine, 
 		actions = append(actions, chromedp.Evaluate(stmt, nil))
 	}
 	err := chromedp.Run(ctx, actions...)
-	if err == nil && !lib_ready {
+	if err == nil && lib_ready.ObjectID != "" {
 		err = ERR_MERMAID_NOT_READY
 	}
 	return &RenderEngine{

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -89,7 +89,7 @@ merge newbranch`},
     C-->D;`},
 		{content: `graph TD;
     A-->B['name'];
-    A-->;`, err_has_prefix: "json: cannot unmarshal object into Go value of type string"},
+    A-->;`, err_has_prefix: `exception "Uncaught`},
 	}
 
 	ctx1 := context.Background()
@@ -111,7 +111,6 @@ merge newbranch`},
 			if !strings.HasPrefix(got, "<svg") {
 				t.Errorf("Render() got = %v", got)
 			}
-			//t.Log(got)
 
 			result_in_bytes, box, err := re1.RenderAsPng(tt.content)
 			if err != nil {

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -64,7 +64,7 @@ branch newbranch
 checkout newbranch
 commit
 commit
-checkout master
+checkout main
 commit
 commit
 merge newbranch`},

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -121,9 +121,9 @@ merge newbranch`},
 				}
 			}
 			if box == nil {
-				t.Errorf("Render() returned an empty box")
+				t.Errorf("RenderAsPng() returned an empty box")
 			} else if box.Width < 1 || box.Height < 1 {
-				t.Errorf("Render() got empty image = w:%d, h:%d)", box.Width, box.Height)
+				t.Errorf("RenderAsPng() got empty image = w:%d, h:%d)", box.Width, box.Height)
 			}
 			content_type := http.DetectContentType(result_in_bytes)
 			if content_type != "image/png" {


### PR DESCRIPTION
Before this change, errors were not visible.

With v9.4.3, I can see now (the error in :

```
=== RUN   TestRenderEngine_Render
    mermaid_test.go:98: NewRenderEngine() error = encountered an undefined value
=== RUN   TestRenderEngine_Render/#00
=== RUN   TestRenderEngine_Render/#01
=== RUN   TestRenderEngine_Render/#02
=== RUN   TestRenderEngine_Render/#03
=== RUN   TestRenderEngine_Render/#04
    mermaid_test.go:112: Render() got = 
    mermaid_test.go:124: Render() returned an empty box
    mermaid_test.go:130: RenderAsPng() return an 'text/plain; charset=utf-8' rather than 'image/png'
=== RUN   TestRenderEngine_Render/#05
=== RUN   TestRenderEngine_Render/#06
=== RUN   TestRenderEngine_Render/#07
=== RUN   TestRenderEngine_Render/#08
    mermaid_test.go:107: Render() error = exception "Uncaught" (1281:1665): Error: Parse error on line 3:
        ...>B['name'];    A-->;
        ----------------------^
        Expecting 'AMP', 'ALPHA', 'COLON', 'PIPE', 'TESTSTR', 'DOWN', 'DEFAULT', 'NUM', 'COMMA', 'MINUS', 'BRKT', 'DOT', 'PUNCTUATION', 'UNICODE_TEXT', 'PLUS', 'EQUALS', 'MULT', 'UNDERSCORE', got 'SEMI'
            at rm.parseError (<anonymous>:1222:48070)
            at rm.parse (<anonymous>:1224:179)
            at Z0e.parser.parse (<anonymous>:1273:5845)
            at Z0e.parser.parse (<anonymous>:1273:5845)
            at Z0e.parser.parse (<anonymous>:1273:5845)
            at Z0e.parser.parse (<anonymous>:1273:5845)
            at Z0e.parser.parse (<anonymous>:1273:5845)
            at Z0e.parse (<anonymous>:1275:54)
            at new Z0e (<anonymous>:1274:8)
            at J0e (<anonymous>:1275:431)
            at Object.bHt [as render] (<anonymous>:1282:487)
            at <anonymous>:1:9
--- FAIL: TestRenderEngine_Render (1.95s)
    --- PASS: TestRenderEngine_Render/#00 (0.19s)
    --- PASS: TestRenderEngine_Render/#01 (0.15s)
    --- PASS: TestRenderEngine_Render/#02 (0.12s)
    --- PASS: TestRenderEngine_Render/#03 (0.25s)
    --- FAIL: TestRenderEngine_Render/#04 (0.03s)
    --- PASS: TestRenderEngine_Render/#05 (0.11s)
    --- PASS: TestRenderEngine_Render/#06 (0.12s)
    --- PASS: TestRenderEngine_Render/#07 (0.10s)
    --- FAIL: TestRenderEngine_Render/#08 (0.01s)
FAIL
FAIL    github.com/dreampuf/mermaid.go  1.954s
FAIL
```

(The last one is due to the changed error message).

With mermaid v10.2.0, I see the following:

```
o test ./...  -v
=== RUN   TestRenderEngine_Render
    mermaid_test.go:98: NewRenderEngine() error = encountered an undefined value
=== RUN   TestRenderEngine_Render/#00
    mermaid_test.go:112: Render() got =
```

and then it gets stuck during PNG rendering, I'm not sure what is causing this.
