### PR TITLE
feat: add option to bundle mermaid diagram into SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # mermaid.go
 
-[mermaid.go][] is a library for invoking [mermaid.js](https://github.com/mermaid-js/mermaid) and getting rending result.
+[mermaid.go][] is a lightweight Go library that bridges [mermaid.js](https://github.com/mermaid-js/mermaid) and Go, allowing you to generate high-quality diagrams (SVG and PNG) directly from your Go applications.
+
+It works by leveraging [chromedp](https://github.com/chromedp/chromedp) to run a headless Chrome/Chromium instance, providing a robust and accurate rendering environment for all Mermaid diagram types.
+
+## Prerequisites
+
+Since this library uses `chromedp`, you must have **Google Chrome** or **Chromium** installed on your system.
+
+## Installation
+
+```shell
+go get -u github.com/dreampuf/mermaid.go
+```
+
+## Architecture
 
 ```mermaid
 sequenceDiagram
@@ -8,46 +22,100 @@ sequenceDiagram
     participant B as mermaid.go
     participant C as chromedp
 
-    A ->>+ B: NewRenderEngine()
-    B ->>+ C: Lanch new instance of chrome and eval JS library
+    A ->>+ B: NewRenderEngine(ctx, ...)
+    B ->>+ C: Launch headless browser and load mermaid.js
     C -->> B: 
-    B -->> A: 
+    B -->> A: RenderEngine instance
     
     loop Render Process
         A ->> B: Render(content, options...)
         B ->> C: mermaid.render()
-        C ->> B: { svg, boxModel, exceptions }
-        B ->> A: Result{ Svg, BoxModel Error }
+        C -->> B: { svg, exceptions }
+        B -->> A: SVG string
+    end
+
+    loop PNG Export
+        A ->> B: RenderAsPng(content)
+        B ->> C: Render to DOM and Capture Screenshot
+        C -->> B: []byte (PNG)
+        B -->> A: Image data
     end
 
     A ->> B: Cancel()
-    B -->> C: Context done
-    C -->>- C: Shutdown chrome instance
+    B -->> C: Context cancelled
+    C -->>- C: Shutdown browser instance
     B -->>- A: 
 ```
 
-Installation:
+## API Overview
 
-```shell
-go get -u github.com/dreampuf/mermaid.go
+### `NewRenderEngine(ctx context.Context, statements []string, options ...chromedp.ExecAllocatorOption) (*RenderEngine, error)`
+Initializes a new render engine by launching a headless browser and loading `mermaid.js`. 
+- `statements`: Optional JavaScript statements to execute during initialization (e.g., custom mermaid configuration).
+- `options`: Variadic list of `chromedp` allocator options.
+
+### `Render(content string, opts ...RenderOption) (string, error)`
+Renders a Mermaid diagram source into an SVG string.
+- `WithBundle()`: An option to include the original Mermaid source code within a `<desc>` tag in the generated SVG.
+
+### `RenderAsPng(content string) ([]byte, *BoxModel, error)`
+Renders a Mermaid diagram source into a PNG image. Returns the raw PNG bytes and the diagram's bounding box dimensions.
+
+### `RenderAsScaledPng(content string, scale float64) ([]byte, *BoxModel, error)`
+Renders a Mermaid diagram into a scaled PNG image. Useful for generating high-resolution outputs.
+
+### `Cancel()`
+Closes the underlying browser instance and releases all associated resources.
+
+## Example
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/dreampuf/mermaid.go"
+)
+
+func main() {
+	ctx := context.Background()
+	// Initialize the engine
+	re, err := mermaid_go.NewRenderEngine(ctx, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer re.Cancel()
+
+	content := "graph TD; A-->B;"
+
+	// Render as SVG with the original source bundled
+	svg, err := re.Render(content, mermaid_go.WithBundle())
+	if err != nil {
+		panic(err)
+	}
+	os.WriteFile("diagram.svg", []byte(svg), 0644)
+
+	// Render as high-res PNG
+	png, _, err := re.RenderAsScaledPng(content, 2.0)
+	if err != nil {
+		panic(err)
+	}
+	os.WriteFile("diagram.png", png, 0644)
+}
 ```
 
-Example: 
+## How to build locally
 
-An example is available [here](example/main.go).
-
-# How to build
-
-1. Checkout the code base
+1. Checkout the code base:
    `git clone https://github.com/dreampuf/mermaid.go.git`
-2. Fetch the latest version of mermaid.js  
+2. Fetch the latest version of `mermaid.js` (optional, as it's already embedded):
     `curl -LO https://unpkg.com/mermaid/dist/mermaid.min.js`
-    Or if you want a specific version
-    `curl -LO https://unpkg.com/mermaid@10.3.0/dist/mermaid.min.js`
-3. Test it  
-   `go test ./...`
+3. Run tests:
+   `go test -v ./...`
 
-# License
+## License
 
 - [mermaid.go][]: MIT License
 - [mermaid.js][]: MIT License

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sequenceDiagram
     B -->> A: 
     
     loop Render Process
-        A ->> B: Render()
+        A ->> B: Render(content, options...)
         B ->> C: mermaid.render()
         C ->> B: { svg, boxModel, exceptions }
         B ->> A: Result{ Svg, BoxModel Error }

--- a/example/main.go
+++ b/example/main.go
@@ -23,7 +23,7 @@ func main() {
     C-->D;`
 
 	// get the render result in SVG/XML string
-	svg_content, err := re.Render(content)
+	svg_content, err := re.Render(content, mermaid_go.WithBundle())
 	if err != nil {
 		panic(err)
 	}

--- a/mermaid.go
+++ b/mermaid.go
@@ -69,17 +69,50 @@ func NewRenderEngine(ctx context.Context, statements []string, options ...chrome
 	}, err
 }
 
-func (r *RenderEngine) Render(content string) (string, error) {
+type RenderOption func(*renderOptions)
+
+type renderOptions struct {
+	bundle bool
+}
+
+func WithBundle() RenderOption {
+	return func(o *renderOptions) {
+		o.bundle = true
+	}
+}
+
+func (r *RenderEngine) Render(content string, opts ...RenderOption) (string, error) {
 	var (
 		result string
 	)
+
+	renderOpts := &renderOptions{}
+	for _, opt := range opts {
+		opt(renderOpts)
+	}
+
 	encodedContent, err := json.Marshal(content)
 	if err != nil {
 		return "", ErrFailedEncoding
 	}
 
+	var script string
+	if renderOpts.bundle {
+		script = fmt.Sprintf(`mermaid.render('mermaid', %s).then(({ svg }) => {
+			const parser = new DOMParser();
+			const doc = parser.parseFromString(svg, 'image/svg+xml');
+			const svgElem = doc.querySelector('svg');
+			const desc = doc.createElementNS('http://www.w3.org/2000/svg', 'desc');
+			desc.textContent = %s;
+			svgElem.insertBefore(desc, svgElem.firstChild);
+			return new XMLSerializer().serializeToString(doc);
+		});`, string(encodedContent), string(encodedContent))
+	} else {
+		script = fmt.Sprintf("mermaid.render('mermaid', %s).then(({ svg }) => { return svg; });", string(encodedContent))
+	}
+
 	err = chromedp.Run(r.ctx,
-		chromedp.Evaluate(fmt.Sprintf("mermaid.render('mermaid', %s).then(({ svg }) => { return svg; });", string(encodedContent)), &result, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+		chromedp.Evaluate(script, &result, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 			return p.WithAwaitPromise(true)
 		}),
 	)

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -103,6 +103,74 @@ Class08 <--> C2: Cool label`},
 	}
 
 	defer re1.Cancel()
+
+	t.Run("BundleDiagram", func(t *testing.T) {
+		content := "graph TD; A-->B;"
+		got, err := re1.Render(content, WithBundle())
+		if err != nil {
+			t.Errorf("Render() error = %v", err)
+		}
+		expected := "graph TD; A--&gt;B;"
+		if !strings.Contains(got, "<desc>"+expected+"</desc>") {
+			t.Errorf("Render() expected to contain <desc>%s</desc>, but got %s", expected, got)
+		}
+	})
+
+	t.Run("InvalidSyntax", func(t *testing.T) {
+		content := "graph TD; A---;" // Invalid syntax
+		_, err := re1.Render(content)
+		if err == nil {
+			t.Error("Render() expected error for invalid syntax, but got nil")
+		}
+	})
+
+	t.Run("Scaling", func(t *testing.T) {
+		content := "graph TD; A-->B;"
+		img1, _, err := re1.RenderAsScaledPng(content, 1.0)
+		if err != nil {
+			t.Fatalf("RenderAsScaledPng(1.0) error = %v", err)
+		}
+		img2, _, err := re1.RenderAsScaledPng(content, 2.0)
+		if err != nil {
+			t.Fatalf("RenderAsScaledPng(2.0) error = %v", err)
+		}
+
+		if len(img2) <= len(img1) {
+			t.Errorf("RenderAsScaledPng() expected larger image data for 2.0 scale than 1.0, got %v bytes vs %v bytes", len(img2), len(img1))
+		}
+	})
+
+	t.Run("Cancel", func(t *testing.T) {
+		ctx := context.Background()
+		re, err := NewRenderEngine(ctx, nil)
+		if err != nil {
+			t.Fatalf("NewRenderEngine() error = %v", err)
+		}
+		re.Cancel()
+		_, err = re.Render("graph TD; A-->B;")
+		if err == nil {
+			t.Error("Render() expected error after Cancel(), but got nil")
+		}
+	})
+
+	t.Run("SequentialRenders", func(t *testing.T) {
+		contents := []string{
+			"graph TD; A-->B;",
+			"sequenceDiagram; Alice->>Bob: Hello;",
+			"pie title Rats; \"Cats\" : 45; \"Dogs\" : 55",
+		}
+		for _, content := range contents {
+			got, err := re1.Render(content)
+			if err != nil {
+				t.Errorf("Render(%s) error = %v", content, err)
+			}
+			if !strings.HasPrefix(got, "<svg") {
+				t.Errorf("Render(%s) got invalid svg", content)
+			}
+		}
+	})
+
+
 	for _, tt := range cases {
 		t.Run("", func(t *testing.T) {
 			got, err := re1.Render(tt.content)


### PR DESCRIPTION
This PR introduces a new WithBundle() option to the Render method, allowing users to embed the original Mermaid diagram source directly within the generated SVG's <desc> tag.

Key changes:
- Implemented functional options pattern for the Render method.
- Added WithBundle() option to inject mermaid source into SVG.
- Added comprehensive unit tests for bundling, invalid syntax, scaling, and sequential renders.
- Updated example and documentation.