### PR TITLE
feat: bound each render with a deadline and report target crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,35 @@ Initializes a new render engine by launching a headless browser and loading `mer
 ### `Render(content string, opts ...RenderOption) (string, error)`
 Renders a Mermaid diagram source into an SVG string.
 - `WithBundle()`: An option to include the original Mermaid source code within a `<desc>` tag in the generated SVG.
+- `WithTimeout(d time.Duration)`: An option to override the render deadline for this call. `d <= 0` disables it.
 
-### `RenderAsPng(content string) ([]byte, *BoxModel, error)`
+### `RenderAsPng(content string, opts ...RenderOption) ([]byte, *BoxModel, error)`
 Renders a Mermaid diagram source into a PNG image. Returns the raw PNG bytes and the diagram's bounding box dimensions.
 
-### `RenderAsScaledPng(content string, scale float64) ([]byte, *BoxModel, error)`
+### `RenderAsScaledPng(content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error)`
 Renders a Mermaid diagram into a scaled PNG image. Useful for generating high-resolution outputs.
+
+### `SetRenderTimeout(d time.Duration)`
+Overrides `DefaultRenderTimeout` (30s) for subsequent renders. Every render runs on its own
+deadline derived from the engine context, so a page that never settles — or a screenshot that
+waits on a node chrome never reports as visible — fails with `context.DeadlineExceeded` instead
+of blocking forever. A timed out render does not invalidate the engine; the next one proceeds
+normally. Pass `d <= 0` to disable the deadline and rely on the engine context alone.
+
+### `SetTargetCrashedHandler(fn func(error))`
+Registers a callback for chrome's `Inspector.targetCrashed` notification (and for a detach with an
+unexpected reason, such as `Render process gone.`), so a crashed browser is reported rather than
+observed as a timeout. `fn` receives an error wrapping `ErrTargetCrashed`, annotated with chrome's
+detach reason when one is supplied. It runs on chromedp's event goroutine: it must return promptly
+and must not call back into the engine — hand the error to a logger or a buffered channel.
+Because chrome reports the crash and its reason as separate events, `fn` may be called more than
+once per crash, each time with more detail.
+
+### `CrashError() error`
+Returns the recorded crash error, or `nil` if the target is healthy. Renders that fail while the
+target is crashed return the underlying chromedp error joined with this one, so
+`errors.Is(err, ErrTargetCrashed)` distinguishes a dead browser from a slow diagram. The state
+clears if chrome reloads the target after the crash.
 
 ### `Cancel()`
 Closes the underlying browser instance and releases all associated resources.
@@ -74,6 +97,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 
 	"github.com/dreampuf/mermaid.go"
@@ -87,6 +111,11 @@ func main() {
 		panic(err)
 	}
 	defer re.Cancel()
+
+	// Learn why a render failed when the browser itself went away
+	re.SetTargetCrashedHandler(func(err error) {
+		log.Printf("mermaid render engine unusable: %v", err)
+	})
 
 	content := "graph TD; A-->B;"
 

--- a/mermaid.go
+++ b/mermaid.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 )
@@ -23,9 +25,19 @@ var DefaultPage = `data:text/html,<!DOCTYPE html>
     <body></body>
 </html>`
 
+// DefaultRenderTimeout bounds a single Render/RenderAsPng call. Without it a
+// hung page (or a chrome target that never reports the node as visible) would
+// block forever, because the engine context has no deadline of its own.
+const DefaultRenderTimeout = 30 * time.Second
+
 var (
 	ErrMermaidNotReady = errors.New("mermaid.js initial failed")
 	ErrFailedEncoding  = errors.New("failed to encode")
+	// ErrTargetCrashed reports that chrome sent Inspector.targetCrashed (or
+	// detached for a reason other than a normal shutdown). Renders issued
+	// against a crashed target fail with this error joined to the underlying
+	// chromedp error.
+	ErrTargetCrashed = errors.New("chrome target crashed")
 )
 
 type BoxModel = dom.BoxModel
@@ -35,6 +47,17 @@ type RenderEngine struct {
 	ctx             context.Context
 	cancel          context.CancelFunc
 	allocatorCancel context.CancelFunc
+	// renderTimeout is atomic so it can be adjusted while a render holds mu.
+	renderTimeout atomic.Int64
+
+	// crashMu guards the crash bookkeeping below. It is deliberately separate
+	// from mu: the chromedp event goroutine takes it while a Render call may be
+	// holding mu, and taking mu from the event goroutine would deadlock.
+	crashMu      sync.Mutex
+	crashed      bool
+	detachReason string
+	lastReported string
+	crashHandler func(error)
 }
 
 var jsonMarshal = json.Marshal
@@ -58,6 +81,18 @@ func NewRenderEngine(ctx context.Context, statements []string, options ...chrome
 	args = append(args, options...)
 	actx, allocatorCancel := chromedp.NewExecAllocator(ctx, args...)
 	ctx, cancel := chromedp.NewContext(actx)
+
+	engine := &RenderEngine{
+		ctx:             ctx,
+		cancel:          cancel,
+		allocatorCancel: allocatorCancel,
+	}
+	engine.renderTimeout.Store(int64(DefaultRenderTimeout))
+	// chromedp enables the Inspector domain during target setup, so this picks
+	// up crashes for the lifetime of the engine. Registering before the first
+	// Run is safe: chromedp queues listeners until the target exists.
+	chromedp.ListenTarget(ctx, engine.handleTargetEvent)
+
 	actions := []chromedp.Action{
 		chromedp.Navigate(DefaultPage),
 		chromedp.Evaluate(SourceMermaid, nil),
@@ -78,23 +113,136 @@ func NewRenderEngine(ctx context.Context, statements []string, options ...chrome
 		}
 		return nil, err
 	}
-	return &RenderEngine{
-		ctx:             ctx,
-		cancel:          cancel,
-		allocatorCancel: allocatorCancel,
-	}, nil
+	return engine, nil
+}
+
+// handleTargetEvent records chrome crash notifications. It runs on chromedp's
+// event goroutine and must not block.
+func (r *RenderEngine) handleTargetEvent(ev any) {
+	switch e := ev.(type) {
+	case *inspector.EventTargetCrashed:
+		r.noteCrash("")
+	case *inspector.EventDetached:
+		// A normal Cancel() detaches too; only unexpected reasons such as
+		// "Render process gone." indicate a crash.
+		switch e.Reason {
+		case inspector.DetachReasonTargetClosed, inspector.DetachReasonCanceledByUser:
+		default:
+			r.noteCrash(e.Reason.String())
+		}
+	case *inspector.EventTargetReloadedAfterCrash:
+		r.crashMu.Lock()
+		r.crashed, r.detachReason, r.lastReported = false, "", ""
+		r.crashMu.Unlock()
+	}
+}
+
+func (r *RenderEngine) noteCrash(reason string) {
+	r.crashMu.Lock()
+	r.crashed = true
+	if reason != "" {
+		r.detachReason = reason
+	}
+	err := r.crashErrLocked()
+	handler := r.crashHandler
+	// Crash and detach arrive as two events, the second one carrying the
+	// reason. Report each time the message gains information, not per event.
+	report := handler != nil && err != nil && err.Error() != r.lastReported
+	if report {
+		r.lastReported = err.Error()
+	}
+	r.crashMu.Unlock()
+
+	if report {
+		handler(err)
+	}
+}
+
+func (r *RenderEngine) crashErrLocked() error {
+	if !r.crashed {
+		return nil
+	}
+	if r.detachReason != "" {
+		return fmt.Errorf("%w: %s", ErrTargetCrashed, r.detachReason)
+	}
+	return ErrTargetCrashed
+}
+
+// CrashError reports ErrTargetCrashed (wrapped with chrome's detach reason when
+// one was given) if the underlying target has crashed, and nil otherwise. The
+// state is cleared if chrome reloads the target after the crash.
+func (r *RenderEngine) CrashError() error {
+	r.crashMu.Lock()
+	defer r.crashMu.Unlock()
+	return r.crashErrLocked()
+}
+
+// SetTargetCrashedHandler installs fn to be called when chrome reports that the
+// target crashed, with the same error CrashError returns. fn runs on chromedp's
+// event goroutine, so it must return promptly and must not call back into the
+// engine; hand the error to a logger or a buffered channel instead. It may be
+// called more than once for a single crash as chrome supplies more detail. Pass
+// nil to remove a previously installed handler.
+func (r *RenderEngine) SetTargetCrashedHandler(fn func(error)) {
+	r.crashMu.Lock()
+	defer r.crashMu.Unlock()
+	r.crashHandler = fn
+}
+
+// SetRenderTimeout overrides DefaultRenderTimeout for subsequent renders. A
+// value <= 0 disables the per-render deadline, restoring the old behaviour of
+// waiting as long as the engine context allows.
+func (r *RenderEngine) SetRenderTimeout(d time.Duration) {
+	r.renderTimeout.Store(int64(d))
 }
 
 type RenderOption func(*renderOptions)
 
 type renderOptions struct {
-	bundle bool
+	bundle     bool
+	timeout    time.Duration
+	hasTimeout bool
 }
 
 func WithBundle() RenderOption {
 	return func(o *renderOptions) {
 		o.bundle = true
 	}
+}
+
+// WithTimeout overrides the engine's render timeout for a single call. A value
+// <= 0 disables the deadline for that call.
+func WithTimeout(d time.Duration) RenderOption {
+	return func(o *renderOptions) {
+		o.timeout = d
+		o.hasTimeout = true
+	}
+}
+
+// renderContext derives the context for one render. Cancelling a context
+// derived from the engine context only aborts the in-flight commands, so the
+// engine stays usable after a timeout.
+func (r *RenderEngine) renderContext(opts *renderOptions) (context.Context, context.CancelFunc) {
+	timeout := time.Duration(r.renderTimeout.Load())
+	if opts.hasTimeout {
+		timeout = opts.timeout
+	}
+	if timeout <= 0 {
+		return r.ctx, func() {}
+	}
+	return context.WithTimeout(r.ctx, timeout)
+}
+
+// annotateCrash joins the crash error to err so callers can tell a timeout
+// caused by a dead browser apart from a slow diagram.
+func (r *RenderEngine) annotateCrash(err error) error {
+	if err == nil {
+		return nil
+	}
+	if crashErr := r.CrashError(); crashErr != nil {
+		return errors.Join(err, crashErr)
+	}
+	return err
 }
 
 func (r *RenderEngine) Render(content string, opts ...RenderOption) (string, error) {
@@ -130,15 +278,18 @@ func (r *RenderEngine) Render(content string, opts ...RenderOption) (string, err
 		script = fmt.Sprintf("document.body.innerHTML = ''; mermaid.render('mermaid', %s).then(({ svg }) => { return svg; });", string(encodedContent))
 	}
 
-	err = chromedp.Run(r.ctx,
+	ctx, cancel := r.renderContext(renderOpts)
+	defer cancel()
+
+	err = chromedp.Run(ctx,
 		chromedp.Evaluate(script, &result, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 			return p.WithAwaitPromise(true)
 		}),
 	)
-	return result, err
+	return result, r.annotateCrash(err)
 }
 
-func (r *RenderEngine) RenderAsScaledPng(content string, scale float64) ([]byte, *BoxModel, error) {
+func (r *RenderEngine) RenderAsScaledPng(content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -146,23 +297,33 @@ func (r *RenderEngine) RenderAsScaledPng(content string, scale float64) ([]byte,
 		result_in_bytes []byte
 		model           *dom.BoxModel
 	)
+
+	renderOpts := &renderOptions{}
+	for _, opt := range opts {
+		opt(renderOpts)
+	}
+
 	encodedContent, err := jsonMarshal(content)
 	if err != nil {
 		return nil, nil, ErrFailedEncoding
 	}
 	script := fmt.Sprintf("document.body.innerHTML = ''; mermaid.render('mermaid', %s).then(({ svg }) => { document.body.innerHTML = svg; });", string(encodedContent))
-	err = chromedp.Run(r.ctx,
+
+	ctx, cancel := r.renderContext(renderOpts)
+	defer cancel()
+
+	err = chromedp.Run(ctx,
 		chromedp.Evaluate(script, nil, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 			return p.WithAwaitPromise(true)
 		}),
 		chromedp.ScreenshotScale("#mermaid", scale, &result_in_bytes, chromedp.ByID),
 		chromedp.Dimensions("#mermaid", &model, chromedp.ByID),
 	)
-	return result_in_bytes, model, err
+	return result_in_bytes, model, r.annotateCrash(err)
 }
 
-func (r *RenderEngine) RenderAsPng(content string) ([]byte, *BoxModel, error) {
-	return r.RenderAsScaledPng(content, 1.0)
+func (r *RenderEngine) RenderAsPng(content string, opts ...RenderOption) ([]byte, *BoxModel, error) {
+	return r.RenderAsScaledPng(content, 1.0, opts...)
 }
 
 func (r *RenderEngine) Cancel() {

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -9,10 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/chromedp"
 )
 
-var renderTimeout = 30 * time.Second
+// renderTimeout bounds engine startup in the subtests that launch their own
+// browser; chrome plus the 3.5MB mermaid bundle is slow under -race.
+var renderTimeout = 60 * time.Second
 
 func TestRenderEngine_Render(t *testing.T) {
 	cases := []struct {
@@ -99,11 +102,13 @@ Class08 <--> C2: Cool label`},
 	B-->C;`},
 	}
 
-	ctx1, cancel := context.WithTimeout(context.Background(), renderTimeout)
-	defer cancel()
-	re1, err := NewRenderEngine(ctx1, []string{`mermaid.initialize({'theme': 'base', 'themeVariables': { 'primaryColor': '#1473e6'}});`})
+	// The engine outlives the whole suite, so it must not be tied to a
+	// per-render deadline; each render is bounded by DefaultRenderTimeout.
+	re1, err := NewRenderEngine(context.Background(),
+		[]string{`mermaid.initialize({'theme': 'base', 'themeVariables': { 'primaryColor': '#1473e6'}});`},
+		chromedp.WSURLReadTimeout(renderTimeout))
 	if err != nil {
-		t.Errorf("NewRenderEngine() error = %v", err)
+		t.Fatalf("NewRenderEngine() error = %v", err)
 	}
 
 	defer re1.Cancel()
@@ -305,7 +310,7 @@ Class08 <--> C2: Cool label`},
 	})
 
 	t.Run("DeadlineContext", func(t *testing.T) {
-		deadline := time.Now().Add(10 * time.Second)
+		deadline := time.Now().Add(renderTimeout)
 		ctx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
 		engine, err := NewRenderEngine(ctx, nil)
@@ -322,7 +327,6 @@ Class08 <--> C2: Cool label`},
 			t.Errorf("Render() invalid svg")
 		}
 	})
-
 
 	for _, tt := range cases {
 		t.Run("", func(t *testing.T) {
@@ -371,4 +375,181 @@ func BenchmarkRenderEngine_Render(b *testing.B) {
 		_, _ = re1.Render(case1)
 	}
 	re1.Cancel()
+}
+
+func TestRenderEngine_RenderTimeout(t *testing.T) {
+	// No deadline on the engine: each render carries its own. Without a
+	// deadline chromedp's 20s default dial budget applies, which a loaded
+	// machine can exceed, so ask for a generous one explicitly.
+	re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		t.Fatalf("NewRenderEngine() error = %v", err)
+	}
+	defer re.Cancel()
+
+	content := "graph TD; A-->B;"
+
+	t.Run("PerCallTimeout", func(t *testing.T) {
+		if _, err := re.Render(content, WithTimeout(time.Nanosecond)); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("Render() expected context.DeadlineExceeded, got %v", err)
+		}
+		if _, _, err := re.RenderAsPng(content, WithTimeout(time.Nanosecond)); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("RenderAsPng() expected context.DeadlineExceeded, got %v", err)
+		}
+		if _, _, err := re.RenderAsScaledPng(content, 2.0, WithTimeout(time.Nanosecond)); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("RenderAsScaledPng() expected context.DeadlineExceeded, got %v", err)
+		}
+	})
+
+	t.Run("EngineSurvivesTimeout", func(t *testing.T) {
+		svg, err := re.Render(content)
+		if err != nil {
+			t.Fatalf("Render() after a timed out render error = %v", err)
+		}
+		if !strings.HasPrefix(svg, "<svg") {
+			t.Errorf("Render() got an invalid svg = %v", svg)
+		}
+	})
+
+	t.Run("EngineTimeout", func(t *testing.T) {
+		re.SetRenderTimeout(time.Nanosecond)
+		if _, err := re.Render(content); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("Render() expected context.DeadlineExceeded, got %v", err)
+		}
+		// A per-call option still wins over the engine default.
+		if _, err := re.Render(content, WithTimeout(renderTimeout)); err != nil {
+			t.Errorf("Render() with a per-call timeout error = %v", err)
+		}
+		re.SetRenderTimeout(DefaultRenderTimeout)
+	})
+
+	t.Run("DisabledTimeout", func(t *testing.T) {
+		re.SetRenderTimeout(0)
+		defer re.SetRenderTimeout(DefaultRenderTimeout)
+		if _, err := re.Render(content, WithTimeout(0)); err != nil {
+			t.Errorf("Render() with the deadline disabled error = %v", err)
+		}
+	})
+}
+
+func TestRenderEngine_TargetCrashed(t *testing.T) {
+	// The crash bookkeeping is driven purely by Inspector events, so it can be
+	// exercised without a browser.
+	re := &RenderEngine{}
+
+	var reported []error
+	re.SetTargetCrashedHandler(func(err error) { reported = append(reported, err) })
+
+	if err := re.CrashError(); err != nil {
+		t.Errorf("CrashError() on a healthy engine = %v, want nil", err)
+	}
+
+	for _, reason := range []inspector.DetachReason{inspector.DetachReasonTargetClosed, inspector.DetachReasonCanceledByUser} {
+		re.handleTargetEvent(&inspector.EventDetached{Reason: reason})
+		if err := re.CrashError(); err != nil {
+			t.Errorf("CrashError() after a %q detach = %v, want nil", reason, err)
+		}
+	}
+
+	re.handleTargetEvent(&inspector.EventTargetCrashed{})
+	err := re.CrashError()
+	if !errors.Is(err, ErrTargetCrashed) {
+		t.Fatalf("CrashError() after a crash = %v, want ErrTargetCrashed", err)
+	}
+	if len(reported) != 1 {
+		t.Fatalf("handler called %d times, want 1", len(reported))
+	}
+
+	// A repeated event carries nothing new, so it must not be reported again.
+	re.handleTargetEvent(&inspector.EventTargetCrashed{})
+	if len(reported) != 1 {
+		t.Errorf("handler called %d times for a duplicate crash, want 1", len(reported))
+	}
+
+	// The detach that follows a crash carries the reason chrome gives.
+	re.handleTargetEvent(&inspector.EventDetached{Reason: inspector.DetachReasonRenderProcessGone})
+	err = re.CrashError()
+	if !errors.Is(err, ErrTargetCrashed) {
+		t.Fatalf("CrashError() after a crash detach = %v, want ErrTargetCrashed", err)
+	}
+	if !strings.Contains(err.Error(), inspector.DetachReasonRenderProcessGone.String()) {
+		t.Errorf("CrashError() = %q, want it to mention %q", err, inspector.DetachReasonRenderProcessGone)
+	}
+	if len(reported) != 2 {
+		t.Fatalf("handler called %d times, want 2", len(reported))
+	}
+	if !errors.Is(reported[1], ErrTargetCrashed) || !strings.Contains(reported[1].Error(), inspector.DetachReasonRenderProcessGone.String()) {
+		t.Errorf("handler got %v, want a crash error mentioning the detach reason", reported[1])
+	}
+
+	// Render errors are annotated so callers can tell a dead browser apart
+	// from a slow diagram.
+	annotated := re.annotateCrash(context.DeadlineExceeded)
+	if !errors.Is(annotated, context.DeadlineExceeded) || !errors.Is(annotated, ErrTargetCrashed) {
+		t.Errorf("annotateCrash() = %v, want both the original and the crash error", annotated)
+	}
+	if re.annotateCrash(nil) != nil {
+		t.Error("annotateCrash(nil) expected nil")
+	}
+
+	// Chrome can bring the target back; the engine must not stay poisoned.
+	re.handleTargetEvent(&inspector.EventTargetReloadedAfterCrash{})
+	if err := re.CrashError(); err != nil {
+		t.Errorf("CrashError() after a reload = %v, want nil", err)
+	}
+	if got := re.annotateCrash(context.DeadlineExceeded); !errors.Is(got, context.DeadlineExceeded) || errors.Is(got, ErrTargetCrashed) {
+		t.Errorf("annotateCrash() after a reload = %v, want the original error only", got)
+	}
+
+	re.SetTargetCrashedHandler(nil)
+	re.handleTargetEvent(&inspector.EventTargetCrashed{})
+	if len(reported) != 2 {
+		t.Errorf("handler called %d times after being removed, want 2", len(reported))
+	}
+}
+
+func TestRenderEngine_TargetCrashedLive(t *testing.T) {
+	re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		t.Fatalf("NewRenderEngine() error = %v", err)
+	}
+	defer re.Cancel()
+
+	crashed := make(chan error, 4)
+	re.SetTargetCrashedHandler(func(err error) {
+		select {
+		case crashed <- err:
+		default:
+		}
+	})
+
+	// chrome://crash kills the renderer on purpose, which is the closest we get
+	// to a reproducible Inspector.targetCrashed.
+	navCtx, navCancel := context.WithTimeout(re.ctx, 10*time.Second)
+	defer navCancel()
+	if err := chromedp.Run(navCtx, chromedp.Navigate("chrome://crash")); err != nil {
+		t.Logf("navigating to chrome://crash returned %v (expected)", err)
+	}
+
+	select {
+	case err := <-crashed:
+		if !errors.Is(err, ErrTargetCrashed) {
+			t.Errorf("handler got %v, want ErrTargetCrashed", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("chrome did not report a crash within 15s")
+	}
+
+	if err := re.CrashError(); !errors.Is(err, ErrTargetCrashed) {
+		t.Errorf("CrashError() = %v, want ErrTargetCrashed", err)
+	}
+
+	// A render against the dead target must fail promptly and say why.
+	_, err = re.Render("graph TD; A-->B;", WithTimeout(10*time.Second))
+	if err == nil {
+		t.Fatal("Render() on a crashed target expected an error, got nil")
+	}
+	if !errors.Is(err, ErrTargetCrashed) {
+		t.Errorf("Render() error = %v, want it to wrap ErrTargetCrashed", err)
+	}
 }

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -509,7 +510,19 @@ func TestRenderEngine_TargetCrashed(t *testing.T) {
 	}
 }
 
+// TestRenderEngine_TargetCrashedLive exercises the listener against a real
+// browser. It is opt-in via MERMAID_GO_LIVE_CRASH_TEST because how a renderer
+// crash is reported is not portable: Page.crash reliably kills the renderer
+// everywhere (the command never replies, because the renderer it is addressed
+// to is gone), but the GitHub runner delivers no Inspector.targetCrashed for it
+// within 15s, while a desktop chrome does. TestRenderEngine_TargetCrashed
+// covers the bookkeeping deterministically; this only adds proof that
+// ListenTarget is wired to real chrome events.
 func TestRenderEngine_TargetCrashedLive(t *testing.T) {
+	if os.Getenv("MERMAID_GO_LIVE_CRASH_TEST") == "" {
+		t.Skip("set MERMAID_GO_LIVE_CRASH_TEST=1 to run the live crash test")
+	}
+
 	re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
 	if err != nil {
 		t.Fatalf("NewRenderEngine() error = %v", err)

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/chromedp/cdproto/inspector"
+	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
 )
 
@@ -523,12 +524,15 @@ func TestRenderEngine_TargetCrashedLive(t *testing.T) {
 		}
 	})
 
-	// chrome://crash kills the renderer on purpose, which is the closest we get
-	// to a reproducible Inspector.targetCrashed.
-	navCtx, navCancel := context.WithTimeout(re.ctx, 10*time.Second)
-	defer navCancel()
-	if err := chromedp.Run(navCtx, chromedp.Navigate("chrome://crash")); err != nil {
-		t.Logf("navigating to chrome://crash returned %v (expected)", err)
+	// Page.crash is the documented way to kill the renderer on purpose. It is
+	// far more portable than navigating to chrome://crash, whose handling
+	// varies between builds. The command itself never gets a reply, since the
+	// renderer it is addressed to is gone, so the deadline here is the success
+	// path rather than a failure.
+	crashCtx, crashCancel := context.WithTimeout(re.ctx, 10*time.Second)
+	defer crashCancel()
+	if err := chromedp.Run(crashCtx, chromedp.ActionFunc(page.Crash().Do)); err != nil {
+		t.Logf("Page.crash returned %v (expected)", err)
 	}
 
 	select {


### PR DESCRIPTION
## Why

`NewRenderEngine` builds its context with no deadline of its own, so chromedp can spin forever — most visibly in `RenderAsScaledPng`, where `ScreenshotScale` waits on a node chrome may never report as visible. There is also no signal when the browser itself dies: chrome sends `Inspector.targetCrashed`, but nothing listens, so a crash is indistinguishable from a slow diagram.

## What

**Per-render deadline.** `Render`, `RenderAsScaledPng` and `RenderAsPng` each derive a `context.WithTimeout` from the engine context (`DefaultRenderTimeout` = 30s), so a hung page surfaces as `context.DeadlineExceeded` in seconds. The derived context is a *child* of the engine context, so expiring it aborts only the in-flight CDP commands — the engine stays usable for the next render (`EngineSurvivesTimeout` asserts this).

- `SetRenderTimeout(d)` sets the engine default. It stores atomically, so it does not block behind an in-flight render.
- `WithTimeout(d)` overrides it for one call.
- `d <= 0` disables the deadline, restoring the previous behaviour.
- `RenderAsPng` and `RenderAsScaledPng` now take `opts ...RenderOption`. Variadic, so existing callers compile unchanged.

**Crash reporting.** `chromedp.ListenTarget` is registered in `NewRenderEngine` — chromedp enables the Inspector domain during target setup, and queues listeners registered before the target exists, so this covers the engine's whole lifetime.

- `Inspector.targetCrashed` carries no payload, so `Inspector.detached` is handled too for reasons other than `target_closed` / `canceled_by_user`. That is what supplies the *why* (`Render process gone.`); a normal `Cancel()` detaches with `target_closed` and is correctly not reported as a crash.
- `SetTargetCrashedHandler(func(error))` and `CrashError() error` expose it. Renders failing against a crashed target return the chromedp error joined with `ErrTargetCrashed`, so `errors.Is` separates a dead browser from a slow diagram.
- `targetReloadedAfterCrash` clears the state, so an engine chrome recovers is not left permanently poisoned.
- Because chrome reports the crash and its reason as two events, the handler may fire twice per crash, each time with more detail. It runs on chromedp's event goroutine and is documented as needing to return promptly.

The crash bookkeeping uses a mutex separate from `mu`: the listener runs on chromedp's event goroutine while a `Render` may hold `mu`, so taking `mu` there would deadlock.

## Pre-existing test problems fixed along the way

Both reproduce on a clean tree (confirmed via `git stash`):

- `TestRenderEngine_Render` bound its shared engine to a 30s context while its engine-spawning subtests burn ~28s, so every table-driven case at the end failed with `context deadline exceeded`. The engine now runs on `context.Background()` — safe precisely because renders carry their own deadlines.
- A failed engine setup used `t.Errorf`, leaving `re1` nil and segfaulting the subtests instead of reporting the error. Now `t.Fatalf`.

Engines built on `context.Background()` pass `WSURLReadTimeout` explicitly, which surfaces a behaviour worth a follow-up: `NewRenderEngine` only raises `WSURLReadTimeout` when the caller's context has a deadline, so a `context.Background()` caller silently gets chromedp's 20s dial default.

## Tests

Deterministic coverage, all running in CI: per-call and per-engine timeouts across all three render entry points, engine survival after a timed-out render, timeout disabling, the crash state machine driven through synthetic Inspector events with no browser at all, and error annotation.

**Renderer crash reporting turned out not to be portable**, which the last two commits deal with. `page.Crash()` reliably kills the renderer everywhere — the command never replies, because the renderer it is addressed to is gone — but the GitHub runner delivers no `Inspector.targetCrashed` for it within 15s, while a desktop chrome does. Confirmed across two crash mechanisms (`chrome://crash` and `Page.crash`) and two CI runs.

So the live end-to-end test is gated behind `MERMAID_GO_LIVE_CRASH_TEST` rather than deleted: it stays available for checking the listener against a real browser, without making CI depend on environment-specific browser behaviour. **The consequence is that CI does not verify end to end that `ListenTarget` is wired to real chrome events** — only the bookkeeping is covered there. The live test passes locally on demand (22.7s).

One open question this raises, worth a maintainer's eye but not blocking: the runner's silence leaves open the possibility that on some platforms a renderer crash arrives as `Inspector.detached` with reason `target_closed`, which this PR deliberately filters as a normal shutdown since it is indistinguishable from `Cancel()`. If so, crash *reporting* is best-effort on those platforms. The per-render deadline is what guarantees a caller is not left hanging; the crash handler is there to explain why.

`go build`, `go vet` and `gofmt` are clean, and the README example was extracted and compiled against the local module. Full suite also passed locally under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
