### PR TITLE
feat: caller-aware timeouts and classifiable render errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,37 @@ Initializes a new render engine by launching a headless browser and loading `mer
 - `statements`: Optional JavaScript statements to execute during initialization (e.g., custom mermaid configuration).
 - `options`: Variadic list of `chromedp` allocator options.
 
+If `ctx` has no deadline, loading the bundle and running `statements` is bounded by
+`DefaultStartupTimeout` (60s); pass a context with a deadline to choose your own. Note that
+`chromedp`'s `WSURLReadTimeout` only covers reading the DevTools URL from chrome's stderr, not this
+work. Bear in mind that `ctx` also governs the **engine's whole lifetime**, so for a long-lived
+engine prefer `context.Background()` and let each render carry its own deadline.
+
 ### `Render(content string, opts ...RenderOption) (string, error)`
 Renders a Mermaid diagram source into an SVG string.
-- `WithBundle()`: An option to include the original Mermaid source code within a `<desc>` tag in the generated SVG.
+- `WithBundle()`: An option to include the original Mermaid source code within a `<desc>` tag in the generated SVG. SVG only — passing it to a PNG method returns `ErrUnsupportedOption` rather than being silently ignored.
 - `WithTimeout(d time.Duration)`: An option to override the render deadline for this call. `d <= 0` disables it.
 
 ### `RenderAsPng(content string, opts ...RenderOption) ([]byte, *BoxModel, error)`
-Renders a Mermaid diagram source into a PNG image. Returns the raw PNG bytes and the diagram's bounding box dimensions.
+Renders a Mermaid diagram source into a PNG image. Returns the raw PNG bytes and the diagram's bounding box dimensions. On failure it returns no image and no box model, so a partial screenshot cannot be mistaken for a complete one.
 
 ### `RenderAsScaledPng(content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error)`
 Renders a Mermaid diagram into a scaled PNG image. Useful for generating high-resolution outputs.
+
+### `RenderContext`, `RenderAsPngContext`, `RenderAsScaledPngContext`
+Context-aware equivalents of the three methods above, taking `ctx context.Context` as the first
+argument. Use these from a server: the context covers **the wait for other renders as well as the
+render itself**, so an abandoned request stops consuming a slot. Renders are serialised on one
+browser tab, and the render deadline only starts once a render begins, so without a context the
+queueing wait is unbounded no matter how short the timeout.
+
+`ctx`'s deadline applies whenever it is sooner than the engine's render timeout, and its
+cancellation is propagated. Only cancellation and the deadline are taken from `ctx` — its values are
+not, because the render has to run on chromedp's own context.
+
+```go
+svg, err := re.RenderContext(req.Context(), content)
+```
 
 ### `SetRenderTimeout(d time.Duration)`
 Overrides `DefaultRenderTimeout` (30s) for subsequent renders. Every render runs on its own
@@ -88,7 +109,22 @@ target is crashed return the underlying chromedp error joined with this one, so
 clears if chrome reloads the target after the crash.
 
 ### `Cancel()`
-Closes the underlying browser instance and releases all associated resources.
+Closes the underlying browser instance and releases all associated resources. It does not wait for
+an in-flight render: it aborts one, rather than queueing behind it.
+
+## Errors
+
+Failures are classified with sentinel errors so callers can branch with `errors.Is` instead of
+matching on messages — which matters mainly for deciding whether a retry is worthwhile:
+
+| Error | Meaning | Retry? |
+| --- | --- | --- |
+| `ErrRenderException` | The page raised a JavaScript exception; almost always an invalid diagram. The `*runtime.ExceptionDetails` stays reachable via `errors.As` for the script location and stack. | No — it will fail identically |
+| `ErrTargetCrashed` | Chrome died. Joined to the underlying error, and reported to `SetTargetCrashedHandler`. | Yes, on a fresh engine |
+| `context.DeadlineExceeded` | The render, or the wait for a turn, outran its deadline. | Maybe |
+| `ErrUnsupportedOption` | A `RenderOption` the called method cannot honour, e.g. `WithBundle()` on a PNG. | No — fix the call |
+| `ErrFailedEncoding` | The diagram source could not be JSON-encoded. Wraps the underlying error. | No |
+| `ErrMermaidNotReady` | `mermaid.js` did not initialise. The message names what `typeof mermaid` actually was. | No |
 
 ## Example
 

--- a/mermaid.go
+++ b/mermaid.go
@@ -30,6 +30,13 @@ var DefaultPage = `data:text/html,<!DOCTYPE html>
 // block forever, because the engine context has no deadline of its own.
 const DefaultRenderTimeout = 30 * time.Second
 
+// DefaultStartupTimeout bounds loading mermaid.js and running the caller's
+// statements in NewRenderEngine when the supplied context has no deadline of its
+// own. WSURLReadTimeout only covers reading the DevTools URL from chrome's
+// stderr, so without this the evaluation of the embedded 3.5MB bundle could hang
+// indefinitely. Pass a context with a deadline to choose a different bound.
+const DefaultStartupTimeout = 60 * time.Second
+
 var (
 	ErrMermaidNotReady = errors.New("mermaid.js initial failed")
 	ErrFailedEncoding  = errors.New("failed to encode")
@@ -38,21 +45,35 @@ var (
 	// against a crashed target fail with this error joined to the underlying
 	// chromedp error.
 	ErrTargetCrashed = errors.New("chrome target crashed")
+	// ErrRenderException reports that the page raised a JavaScript exception,
+	// which for a render almost always means the diagram source is invalid.
+	// It is worth separating from the transport and lifecycle failures: retrying
+	// it will fail identically, whereas retrying ErrTargetCrashed or a timeout
+	// may well succeed. The *runtime.ExceptionDetails chrome supplied stays
+	// reachable with errors.As for the script location and stack.
+	ErrRenderException = errors.New("render raised a javascript exception")
+	// ErrUnsupportedOption reports a RenderOption that the called method cannot
+	// honour, rather than ignoring it. WithBundle is the only such option: it
+	// embeds the source in the SVG's <desc>, which a PNG has nowhere to put.
+	ErrUnsupportedOption = errors.New("unsupported render option")
 )
 
 type BoxModel = dom.BoxModel
 
 type RenderEngine struct {
-	mu              sync.Mutex
+	// sem serialises renders. It is a one-slot channel rather than a mutex so
+	// that waiting for a turn can be abandoned when the caller's context is
+	// cancelled; sync.Mutex offers no such thing.
+	sem             chan struct{}
 	ctx             context.Context
 	cancel          context.CancelFunc
 	allocatorCancel context.CancelFunc
-	// renderTimeout is atomic so it can be adjusted while a render holds mu.
+	// renderTimeout is atomic so it can be adjusted while a render is running.
 	renderTimeout atomic.Int64
 
 	// crashMu guards the crash bookkeeping below. It is deliberately separate
-	// from mu: the chromedp event goroutine takes it while a Render call may be
-	// holding mu, and taking mu from the event goroutine would deadlock.
+	// from sem: the chromedp event goroutine takes it while a render is in
+	// flight, and making that goroutine wait for a render would deadlock.
 	crashMu      sync.Mutex
 	crashed      bool
 	detachReason string
@@ -83,6 +104,7 @@ func NewRenderEngine(ctx context.Context, statements []string, options ...chrome
 	ctx, cancel := chromedp.NewContext(actx)
 
 	engine := &RenderEngine{
+		sem:             make(chan struct{}, 1),
 		ctx:             ctx,
 		cancel:          cancel,
 		allocatorCancel: allocatorCancel,
@@ -102,9 +124,26 @@ func NewRenderEngine(ctx context.Context, statements []string, options ...chrome
 		actions = append(actions, chromedp.Evaluate(stmt, nil))
 	}
 	actions = append(actions, chromedp.Evaluate("typeof mermaid", &result))
-	err := chromedp.Run(ctx, actions...)
+
+	// Allocate the browser against the engine context before bounding anything.
+	// chromedp starts chrome with exec.CommandContext using whichever context
+	// reaches the first Run, so running the initialisation under a derived
+	// deadline would tie chrome's lifetime to that deadline and kill it the
+	// moment this function returned.
+	err := chromedp.Run(ctx)
+	if err == nil {
+		startCtx := ctx
+		if _, ok := ctx.Deadline(); !ok {
+			var startCancel context.CancelFunc
+			startCtx, startCancel = context.WithTimeout(ctx, DefaultStartupTimeout)
+			defer startCancel()
+		}
+		err = chromedp.Run(startCtx, actions...)
+	}
 	if err == nil && result != "object" {
-		err = ErrMermaidNotReady
+		// The value is the whole diagnostic: "undefined" means the bundle never
+		// defined mermaid, anything else means it was replaced.
+		err = fmt.Errorf("%w: typeof mermaid = %q", ErrMermaidNotReady, result)
 	}
 	if err != nil {
 		cancel()
@@ -219,25 +258,89 @@ func WithTimeout(d time.Duration) RenderOption {
 	}
 }
 
-// renderContext derives the context for one render. Cancelling a context
-// derived from the engine context only aborts the in-flight commands, so the
-// engine stays usable after a timeout.
-func (r *RenderEngine) renderContext(opts *renderOptions) (context.Context, context.CancelFunc) {
+// acquire waits for this render's turn, giving up if the caller's context is
+// cancelled or the engine is closed. Without it a caller could sit behind an
+// unbounded queue of other renders with no way out, because the per-render
+// deadline only starts once a render actually begins.
+func (r *RenderEngine) acquire(ctx context.Context) (release func(), err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, r.renderErr(ctx, err)
+	}
+	select {
+	case r.sem <- struct{}{}:
+		return func() { <-r.sem }, nil
+	case <-ctx.Done():
+		return nil, r.renderErr(ctx, ctx.Err())
+	case <-r.ctx.Done():
+		return nil, r.annotateCrash(r.ctx.Err())
+	}
+}
+
+// renderErr classifies a failed render. When the caller's context is what ended
+// it, the derived context reports a bare Canceled; the caller's own cause says
+// why, so prefer it.
+func (r *RenderEngine) renderErr(caller context.Context, err error) error {
+	if errors.Is(err, context.Canceled) {
+		if cause := context.Cause(caller); cause != nil {
+			err = cause
+		}
+	}
+	return r.annotateCrash(err)
+}
+
+// renderContext derives the context for one render. It is rooted at the engine
+// context because that is what carries chromedp's target; the caller's context
+// contributes its deadline and its cancellation, but not its values.
+//
+// Cancelling a context derived from the engine context only aborts the in-flight
+// commands, so the engine stays usable after a timeout. This is not true of the
+// very first Run against a fresh engine, which is why NewRenderEngine allocates
+// the browser separately -- see the comment there.
+func (r *RenderEngine) renderContext(caller context.Context, opts *renderOptions) (context.Context, context.CancelFunc) {
 	timeout := time.Duration(r.renderTimeout.Load())
 	if opts.hasTimeout {
 		timeout = opts.timeout
 	}
-	if timeout <= 0 {
-		return r.ctx, func() {}
+
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	// Honour whichever of the two deadlines lands first, so a caller asking for
+	// less than the engine's timeout gets a truthful DeadlineExceeded rather
+	// than the bare Canceled that propagation alone would produce.
+	deadline, hasDeadline := caller.Deadline()
+	switch {
+	case timeout > 0 && hasDeadline && time.Now().Add(timeout).Before(deadline):
+		ctx, cancel = context.WithTimeout(r.ctx, timeout)
+	case hasDeadline:
+		ctx, cancel = context.WithDeadline(r.ctx, deadline)
+	case timeout > 0:
+		ctx, cancel = context.WithTimeout(r.ctx, timeout)
+	default:
+		ctx, cancel = context.WithCancel(r.ctx)
 	}
-	return context.WithTimeout(r.ctx, timeout)
+
+	stop := context.AfterFunc(caller, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
 }
 
-// annotateCrash joins the crash error to err so callers can tell a timeout
-// caused by a dead browser apart from a slow diagram.
+// annotateCrash classifies a render failure so callers can act on it without
+// matching on error strings: it joins the crash error when the browser has died,
+// and tags a JavaScript exception so an invalid diagram is distinguishable from
+// an infrastructure failure.
 func (r *RenderEngine) annotateCrash(err error) error {
 	if err == nil {
 		return nil
+	}
+	// chromedp returns *runtime.ExceptionDetails as the error itself, which is
+	// discoverable only if you already know to look for it.
+	var exception *runtime.ExceptionDetails
+	if errors.As(err, &exception) {
+		err = fmt.Errorf("%w: %w", ErrRenderException, err)
 	}
 	if crashErr := r.CrashError(); crashErr != nil {
 		return errors.Join(err, crashErr)
@@ -245,10 +348,19 @@ func (r *RenderEngine) annotateCrash(err error) error {
 	return err
 }
 
+// Render renders content to SVG. It is equivalent to RenderContext with a
+// background context, so it cannot be cancelled by the caller and is bounded
+// only by the engine's render timeout.
 func (r *RenderEngine) Render(content string, opts ...RenderOption) (string, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	return r.RenderContext(context.Background(), content, opts...)
+}
 
+// RenderContext renders content to SVG, giving up if ctx is cancelled. The
+// context covers the wait for other renders to finish as well as the render
+// itself, and its deadline applies if it is sooner than the engine's render
+// timeout. Only cancellation and the deadline are taken from ctx; its values are
+// not, because the render has to run on chromedp's own context.
+func (r *RenderEngine) RenderContext(ctx context.Context, content string, opts ...RenderOption) (string, error) {
 	var (
 		result string
 	)
@@ -260,8 +372,14 @@ func (r *RenderEngine) Render(content string, opts ...RenderOption) (string, err
 
 	encodedContent, err := jsonMarshal(content)
 	if err != nil {
-		return "", ErrFailedEncoding
+		return "", fmt.Errorf("%w: %w", ErrFailedEncoding, err)
 	}
+
+	release, err := r.acquire(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
 
 	var script string
 	if renderOpts.bundle {
@@ -278,21 +396,31 @@ func (r *RenderEngine) Render(content string, opts ...RenderOption) (string, err
 		script = fmt.Sprintf("document.body.innerHTML = ''; mermaid.render('mermaid', %s).then(({ svg }) => { return svg; });", string(encodedContent))
 	}
 
-	ctx, cancel := r.renderContext(renderOpts)
+	runCtx, cancel := r.renderContext(ctx, renderOpts)
 	defer cancel()
 
-	err = chromedp.Run(ctx,
+	err = chromedp.Run(runCtx,
 		chromedp.Evaluate(script, &result, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 			return p.WithAwaitPromise(true)
 		}),
 	)
-	return result, r.annotateCrash(err)
+	if err != nil {
+		return "", r.renderErr(ctx, err)
+	}
+	return result, nil
 }
 
+// RenderAsScaledPng renders content to a PNG at the given scale. It is
+// equivalent to RenderAsScaledPngContext with a background context.
 func (r *RenderEngine) RenderAsScaledPng(content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	return r.RenderAsScaledPngContext(context.Background(), content, scale, opts...)
+}
 
+// RenderAsScaledPngContext renders content to a PNG at the given scale, giving
+// up if ctx is cancelled. See RenderContext for how ctx is applied. On failure
+// it returns no image and no box model, so a caller cannot mistake a partial
+// screenshot for a complete one.
+func (r *RenderEngine) RenderAsScaledPngContext(ctx context.Context, content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error) {
 	var (
 		result_in_bytes []byte
 		model           *dom.BoxModel
@@ -302,33 +430,54 @@ func (r *RenderEngine) RenderAsScaledPng(content string, scale float64, opts ...
 	for _, opt := range opts {
 		opt(renderOpts)
 	}
+	if renderOpts.bundle {
+		return nil, nil, fmt.Errorf("%w: WithBundle has no effect on a PNG, the source is embedded in the SVG's <desc>", ErrUnsupportedOption)
+	}
 
 	encodedContent, err := jsonMarshal(content)
 	if err != nil {
-		return nil, nil, ErrFailedEncoding
+		return nil, nil, fmt.Errorf("%w: %w", ErrFailedEncoding, err)
 	}
 	script := fmt.Sprintf("document.body.innerHTML = ''; mermaid.render('mermaid', %s).then(({ svg }) => { document.body.innerHTML = svg; });", string(encodedContent))
 
-	ctx, cancel := r.renderContext(renderOpts)
+	release, err := r.acquire(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer release()
+
+	runCtx, cancel := r.renderContext(ctx, renderOpts)
 	defer cancel()
 
-	err = chromedp.Run(ctx,
+	err = chromedp.Run(runCtx,
 		chromedp.Evaluate(script, nil, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 			return p.WithAwaitPromise(true)
 		}),
 		chromedp.ScreenshotScale("#mermaid", scale, &result_in_bytes, chromedp.ByID),
 		chromedp.Dimensions("#mermaid", &model, chromedp.ByID),
 	)
-	return result_in_bytes, model, r.annotateCrash(err)
+	if err != nil {
+		return nil, nil, r.renderErr(ctx, err)
+	}
+	return result_in_bytes, model, nil
 }
 
+// RenderAsPng renders content to a PNG. It is equivalent to
+// RenderAsPngContext with a background context.
 func (r *RenderEngine) RenderAsPng(content string, opts ...RenderOption) ([]byte, *BoxModel, error) {
-	return r.RenderAsScaledPng(content, 1.0, opts...)
+	return r.RenderAsScaledPngContext(context.Background(), content, 1.0, opts...)
 }
 
+// RenderAsPngContext renders content to a PNG, giving up if ctx is cancelled.
+func (r *RenderEngine) RenderAsPngContext(ctx context.Context, content string, opts ...RenderOption) ([]byte, *BoxModel, error) {
+	return r.RenderAsScaledPngContext(ctx, content, 1.0, opts...)
+}
+
+// Cancel closes the browser and releases every resource held by the engine. It
+// deliberately does not wait for an in-flight render: context.CancelFunc is safe
+// for concurrent use, so cancelling straight away aborts a render in progress
+// instead of queueing behind it. Calling it more than once is harmless.
 func (r *RenderEngine) Cancel() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.cancel()
 	if r.allocatorCancel != nil {
 		r.allocatorCancel()

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 )
 
@@ -22,7 +23,7 @@ var renderTimeout = 60 * time.Second
 func TestRenderEngine_Render(t *testing.T) {
 	cases := []struct {
 		content/*, result */ string
-		err_has_prefix string
+		wantException bool
 	}{
 		{content: `graph TD;
     A-->B;
@@ -98,7 +99,7 @@ Class08 <--> C2: Cool label`},
     C-->D;`},
 		{content: `graph TD;
     A-->B['name'];
-    A-->;`, err_has_prefix: `exception "Uncaught`},
+    A-->;`, wantException: true},
 		{content: `graph TD;
 	A-->B["` + "`Hello World`" + `"];
 	B-->C;`},
@@ -334,11 +335,18 @@ Class08 <--> C2: Cool label`},
 		t.Run("", func(t *testing.T) {
 			got, err := re1.Render(tt.content)
 			t.Logf("got %s, error %s", got, err)
-			if err != nil {
-				if tt.err_has_prefix != "" && strings.HasPrefix(err.Error(), tt.err_has_prefix) {
-					// expected exception
-					return
+			if tt.wantException {
+				// Classified rather than matched on the message, so the
+				// assertion survives a reworded chrome exception.
+				if !errors.Is(err, ErrRenderException) {
+					t.Errorf("Render() error = %v, want ErrRenderException", err)
 				}
+				if _, _, err := re1.RenderAsPng(tt.content); !errors.Is(err, ErrRenderException) {
+					t.Errorf("RenderAsPng() error = %v, want ErrRenderException", err)
+				}
+				return
+			}
+			if err != nil {
 				t.Errorf("Render() error = %v", err)
 			}
 			if !strings.HasPrefix(got, "<svg") {
@@ -347,10 +355,7 @@ Class08 <--> C2: Cool label`},
 
 			result_in_bytes, box, err := re1.RenderAsPng(tt.content)
 			if err != nil {
-				if !strings.HasPrefix(err.Error(), tt.err_has_prefix) {
-					t.Errorf("Render() error = %v", err)
-					return
-				}
+				t.Fatalf("RenderAsPng() error = %v", err)
 			}
 			if box == nil {
 				t.Errorf("RenderAsPng() returned an empty box")
@@ -569,4 +574,256 @@ func TestRenderEngine_TargetCrashedLive(t *testing.T) {
 	if !errors.Is(err, ErrTargetCrashed) {
 		t.Errorf("Render() error = %v, want it to wrap ErrTargetCrashed", err)
 	}
+}
+
+func TestRenderEngine_RenderContext(t *testing.T) {
+	re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		t.Fatalf("NewRenderEngine() error = %v", err)
+	}
+	defer re.Cancel()
+
+	content := "graph TD; A-->B;"
+
+	t.Run("Succeeds", func(t *testing.T) {
+		svg, err := re.RenderContext(context.Background(), content)
+		if err != nil {
+			t.Fatalf("RenderContext() error = %v", err)
+		}
+		if !strings.HasPrefix(svg, "<svg") {
+			t.Errorf("RenderContext() got an invalid svg = %v", svg)
+		}
+	})
+
+	t.Run("AlreadyCancelledFailsFast", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := re.RenderContext(ctx, content); !errors.Is(err, context.Canceled) {
+			t.Errorf("RenderContext() error = %v, want context.Canceled", err)
+		}
+		if _, _, err := re.RenderAsPngContext(ctx, content); !errors.Is(err, context.Canceled) {
+			t.Errorf("RenderAsPngContext() error = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("CancelledWhileQueued", func(t *testing.T) {
+		// Occupy the engine so the call has to queue. This is the case a
+		// caller could not escape before: the render timeout only starts once
+		// a render begins, so the wait for a turn was unbounded.
+		re.sem <- struct{}{}
+		defer func() { <-re.sem }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err := re.RenderContext(ctx, content)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("RenderContext() error = %v, want context.DeadlineExceeded", err)
+		}
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Errorf("RenderContext() waited %v for a turn, want it to give up with the context", elapsed)
+		}
+	})
+
+	t.Run("CancellationCauseIsReported", func(t *testing.T) {
+		re.sem <- struct{}{}
+		defer func() { <-re.sem }()
+
+		reason := errors.New("caller went away")
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(reason)
+
+		if _, err := re.RenderContext(ctx, content); !errors.Is(err, reason) {
+			t.Errorf("RenderContext() error = %v, want it to report the cancellation cause", err)
+		}
+	})
+}
+
+func TestRenderEngine_renderContext(t *testing.T) {
+	// The deadline arithmetic is worth checking directly: it decides whether a
+	// caller sees a truthful DeadlineExceeded or a bare Canceled.
+	re := &RenderEngine{sem: make(chan struct{}, 1), ctx: context.Background()}
+
+	t.Run("CallerDeadlineWinsWhenSooner", func(t *testing.T) {
+		re.SetRenderTimeout(time.Hour)
+		want := time.Now().Add(2 * time.Second)
+		caller, cancel := context.WithDeadline(context.Background(), want)
+		defer cancel()
+
+		ctx, done := re.renderContext(caller, &renderOptions{})
+		defer done()
+
+		got, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("renderContext() produced no deadline")
+		}
+		if got.Sub(want).Abs() > 50*time.Millisecond {
+			t.Errorf("renderContext() deadline = %v, want the caller's %v", got, want)
+		}
+	})
+
+	t.Run("EngineTimeoutWinsWhenSooner", func(t *testing.T) {
+		re.SetRenderTimeout(time.Second)
+		caller, cancel := context.WithTimeout(context.Background(), time.Hour)
+		defer cancel()
+
+		ctx, done := re.renderContext(caller, &renderOptions{})
+		defer done()
+
+		got, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("renderContext() produced no deadline")
+		}
+		if until := time.Until(got); until > 5*time.Second {
+			t.Errorf("renderContext() deadline is %v away, want the engine's 1s", until)
+		}
+	})
+
+	t.Run("CallerCancellationPropagates", func(t *testing.T) {
+		re.SetRenderTimeout(time.Hour)
+		caller, cancel := context.WithCancel(context.Background())
+
+		ctx, done := re.renderContext(caller, &renderOptions{})
+		defer done()
+
+		cancel()
+		select {
+		case <-ctx.Done():
+		case <-time.After(5 * time.Second):
+			t.Error("renderContext() did not propagate the caller's cancellation")
+		}
+	})
+
+	t.Run("NoDeadlineWhenBothDisabled", func(t *testing.T) {
+		re.SetRenderTimeout(0)
+		ctx, done := re.renderContext(context.Background(), &renderOptions{})
+		defer done()
+		if _, ok := ctx.Deadline(); ok {
+			t.Error("renderContext() set a deadline when both the engine and the caller declined one")
+		}
+	})
+}
+
+func TestRenderEngine_CancelDoesNotWaitForRender(t *testing.T) {
+	re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		t.Fatalf("NewRenderEngine() error = %v", err)
+	}
+
+	// Stand in for a render in flight. Cancel used to take the same lock, so
+	// shutdown queued behind the render it was meant to abort.
+	re.sem <- struct{}{}
+	defer func() { <-re.sem }()
+
+	done := make(chan struct{})
+	go func() {
+		re.Cancel()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Cancel() blocked behind an in-flight render")
+	}
+}
+
+func TestRenderEngine_ErrorClassification(t *testing.T) {
+	re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		t.Fatalf("NewRenderEngine() error = %v", err)
+	}
+	defer re.Cancel()
+
+	t.Run("InvalidDiagramIsAnException", func(t *testing.T) {
+		_, err := re.Render("graph TD; A---;")
+		if !errors.Is(err, ErrRenderException) {
+			t.Fatalf("Render() error = %v, want ErrRenderException", err)
+		}
+		// The chrome detail stays reachable for the script location and stack.
+		var exception *runtime.ExceptionDetails
+		if !errors.As(err, &exception) {
+			t.Errorf("Render() error = %v, want the *runtime.ExceptionDetails to remain reachable", err)
+		}
+		// An invalid diagram is not a browser failure; retrying it is pointless
+		// whereas retrying a crash is not, so the two must not be conflated.
+		if errors.Is(err, ErrTargetCrashed) {
+			t.Errorf("Render() error = %v, should not report a crash", err)
+		}
+	})
+
+	t.Run("NoPartialPngOnFailure", func(t *testing.T) {
+		png, box, err := re.RenderAsPng("graph TD; A---;")
+		if err == nil {
+			t.Fatal("RenderAsPng() expected an error for invalid syntax")
+		}
+		if png != nil || box != nil {
+			t.Errorf("RenderAsPng() returned png=%d bytes, box=%v on failure, want neither", len(png), box)
+		}
+	})
+
+	t.Run("BundleIsRejectedForPng", func(t *testing.T) {
+		// Previously accepted and silently ignored, because the PNG methods take
+		// RenderOptions but only Render implements bundling.
+		if _, _, err := re.RenderAsPng("graph TD; A-->B;", WithBundle()); !errors.Is(err, ErrUnsupportedOption) {
+			t.Errorf("RenderAsPng(WithBundle()) error = %v, want ErrUnsupportedOption", err)
+		}
+		if _, _, err := re.RenderAsScaledPng("graph TD; A-->B;", 2.0, WithBundle()); !errors.Is(err, ErrUnsupportedOption) {
+			t.Errorf("RenderAsScaledPng(WithBundle()) error = %v, want ErrUnsupportedOption", err)
+		}
+	})
+
+	t.Run("EncodingErrorIsWrapped", func(t *testing.T) {
+		oldJSONMarshal := jsonMarshal
+		defer func() { jsonMarshal = oldJSONMarshal }()
+		underlying := errors.New("mock marshal error")
+		jsonMarshal = func(v any) ([]byte, error) { return nil, underlying }
+
+		_, err := re.Render("graph TD; A-->B;")
+		if !errors.Is(err, ErrFailedEncoding) {
+			t.Errorf("Render() error = %v, want ErrFailedEncoding", err)
+		}
+		if !errors.Is(err, underlying) {
+			t.Errorf("Render() error = %v, want the underlying marshal error preserved", err)
+		}
+	})
+}
+
+func TestRenderEngine_StartupDiagnostics(t *testing.T) {
+	t.Run("MermaidNotReadyNamesTheValue", func(t *testing.T) {
+		engine, err := NewRenderEngine(context.Background(), []string{"delete window.mermaid"},
+			chromedp.WSURLReadTimeout(renderTimeout))
+		if !errors.Is(err, ErrMermaidNotReady) {
+			t.Fatalf("NewRenderEngine() error = %v, want ErrMermaidNotReady", err)
+		}
+		if engine != nil {
+			t.Error("NewRenderEngine() expected nil engine on error")
+		}
+		// Knowing what typeof mermaid actually was is the whole diagnostic.
+		if !strings.Contains(err.Error(), `"undefined"`) {
+			t.Errorf("NewRenderEngine() error = %q, want it to name the typeof result", err)
+		}
+	})
+
+	t.Run("StartupDeadlineDoesNotKillChrome", func(t *testing.T) {
+		// chromedp binds chrome's process to the context of the first Run, so
+		// bounding startup with a derived deadline would kill the browser as
+		// soon as NewRenderEngine returned. Renders afterwards prove it did not.
+		re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+		if err != nil {
+			t.Fatalf("NewRenderEngine() error = %v", err)
+		}
+		defer re.Cancel()
+
+		for i := range 2 {
+			svg, err := re.Render("graph TD; A-->B;")
+			if err != nil {
+				t.Fatalf("Render() %d after a bounded startup error = %v", i, err)
+			}
+			if !strings.HasPrefix(svg, "<svg") {
+				t.Errorf("Render() %d got an invalid svg = %v", i, svg)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Follow-up to #72. Six related gaps, all about a caller's ability to bound a render and to find out what went wrong.

## Timeouts and cancellation

**Renders could not be bounded by the caller at all.** They serialise on a single browser tab, and the render deadline only starts once a render *begins* — so the wait for a turn was unbounded no matter how short the timeout. A cancelled HTTP request still held its slot. Adds `RenderContext`, `RenderAsPngContext` and `RenderAsScaledPngContext`, whose context covers the queueing wait as well as the render:

```go
svg, err := re.RenderContext(req.Context(), content)
```

The caller's deadline applies when it is sooner than the engine's, so the error stays a truthful `DeadlineExceeded` rather than the bare `Canceled` that propagation alone would produce, and the cancellation *cause* is reported when there is one. This needs the mutex replaced with a one-slot channel, since a `sync.Mutex` cannot be acquired with a context. Only cancellation and the deadline come from the caller's context, not its values, because the render has to run on chromedp's context — documented on the methods.

**`Cancel()` queued behind the render it was meant to abort**, because it took that same lock. `context.CancelFunc` is safe for concurrent use, so the lock bought nothing; shutdown is now immediate and interrupts an in-flight render.

**Startup was still unbounded** when the context had no deadline — which is exactly what the README recommends for a long-lived engine, since renders now carry their own. `WSURLReadTimeout` only covers reading the DevTools URL from chrome's stderr, not evaluating the embedded 3.5 MB bundle or the caller's `statements`. Now bounded by `DefaultStartupTimeout` (60s).

That one had a trap worth flagging: **the browser must be allocated against the engine context first.** chromedp starts chrome with `exec.CommandContext` using whichever context reaches the *first* `Run`, so wrapping the initialisation in a derived deadline would tie chrome's process lifetime to that deadline and kill the browser the moment `NewRenderEngine` returned. `StartupDeadlineDoesNotKillChrome` guards it.

## Error propagation

**An invalid diagram and a dead browser were both just "an error"**, so a caller could not tell what was worth retrying — retrying a syntax error loops forever, while rejecting a crash discards a recoverable request. chromedp returns `*runtime.ExceptionDetails` as the error itself, which is discoverable only if you already know to look for it. Now tagged `ErrRenderException`, with the details still reachable through `errors.As`:

| Error | Meaning | Retry? |
| --- | --- | --- |
| `ErrRenderException` | Page raised a JS exception; almost always an invalid diagram | No |
| `ErrTargetCrashed` | Chrome died | Yes, on a fresh engine |
| `context.DeadlineExceeded` | Render, or the wait for a turn, outran its deadline | Maybe |
| `ErrUnsupportedOption` | Option the method cannot honour | No — fix the call |
| `ErrFailedEncoding` | Source could not be JSON-encoded | No |
| `ErrMermaidNotReady` | `mermaid.js` did not initialise | No |

Also: `ErrFailedEncoding` discarded the underlying error and `ErrMermaidNotReady` discarded the `typeof` result, which is the entire diagnostic — both now wrapped, so `ErrMermaidNotReady` tells you whether mermaid was `"undefined"` or something replaced it.

**`WithBundle()` on a PNG was accepted and silently ignored** — a footgun #72 introduced by giving the PNG methods `RenderOption`. It embeds the source in the SVG's `<desc>`, which a PNG has nowhere to put, so it now returns `ErrUnsupportedOption`.

**A failed PNG render returned partial output**, and the box model could be nil — the old table test dereferenced `box.Width` on the error path behind only a nil check. Now returns neither.

## Tests

New: context cancellation (pre-cancelled, cancelled while queued, cause reporting), the deadline arithmetic unit-tested directly in both directions, `Cancel()` not blocking behind a render, exception classification including `errors.As` reachability, no partial PNG, `WithBundle` rejection, wrapped encoding error, `ErrMermaidNotReady` naming the value, and the chrome-not-killed-by-startup-deadline guard.

The table test now asserts `errors.Is(err, ErrRenderException)` instead of a prefix of the message, so it no longer breaks when chrome rewords an exception.

`go build`, `go vet`, `gofmt` clean; full suite passes, and passes under `-race` (52s). The opt-in live crash test from #72 still passes (`MERMAID_GO_LIVE_CRASH_TEST=1`), confirming the new `acquire` path does not disturb crash reporting. README example extracted and compiled.

One note on shape: this is a single commit covering six changes because they interlock (the semaphore is what makes the context methods possible, and that is what makes `Cancel` non-blocking). Happy to split it into per-change commits if you would rather review them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
