### PR TITLE
feat: distinguish a closed engine, and assorted cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Registers a callback for chrome's `Inspector.targetCrashed` notification (and fo
 unexpected reason, such as `Render process gone.`), so a crashed browser is reported rather than
 observed as a timeout. `fn` receives an error wrapping `ErrTargetCrashed`, annotated with chrome's
 detach reason when one is supplied. It runs on chromedp's event goroutine: it must return promptly
-and must not call back into the engine — hand the error to a logger or a buffered channel.
+and must not call back into the engine — hand the error to a logger or a buffered channel. A panic
+in `fn` is recovered rather than being allowed to take the process down, but it is then discarded,
+so do not rely on it surfacing anywhere.
 Because chrome reports the crash and its reason as separate events, `fn` may be called more than
 once per crash, each time with more detail.
 
@@ -110,7 +112,8 @@ clears if chrome reloads the target after the crash.
 
 ### `Cancel()`
 Closes the underlying browser instance and releases all associated resources. It does not wait for
-an in-flight render: it aborts one, rather than queueing behind it.
+an in-flight render: it aborts one, rather than queueing behind it. Every subsequent render fails
+with `ErrEngineClosed`.
 
 ## Errors
 
@@ -125,6 +128,7 @@ matching on messages — which matters mainly for deciding whether a retry is wo
 | `ErrUnsupportedOption` | A `RenderOption` the called method cannot honour, e.g. `WithBundle()` on a PNG. | No — fix the call |
 | `ErrFailedEncoding` | The diagram source could not be JSON-encoded. Wraps the underlying error. | No |
 | `ErrMermaidNotReady` | `mermaid.js` did not initialise. The message names what `typeof mermaid` actually was. | No |
+| `ErrEngineClosed` | The engine's context is done, because `Cancel()` was called or the context passed to `NewRenderEngine` was cancelled. Without it this is indistinguishable from a cancelled caller, yet it needs the opposite response. | No — build a new engine |
 
 ## Example
 

--- a/mermaid.go
+++ b/mermaid.go
@@ -1,3 +1,24 @@
+// Package mermaid_go renders [mermaid.js] diagrams to SVG and PNG from Go.
+//
+// It drives a headless Chrome through [chromedp]. NewRenderEngine launches the
+// browser once and loads the embedded mermaid.js bundle into a page; each render
+// then reuses that page, so the browser is started once rather than per diagram.
+// An engine owns operating system resources and must be released with
+// [RenderEngine.Cancel].
+//
+// Renders are serialised on the engine's single page. Prefer the context-aware
+// methods ([RenderEngine.RenderContext] and friends) in a server: their context
+// bounds the wait for a turn as well as the render itself.
+//
+// Failures are classified with sentinel errors so callers can branch with
+// [errors.Is] rather than on messages, which mainly decides whether a retry is
+// worthwhile: [ErrRenderException] means the diagram is invalid and will fail
+// identically next time, whereas [ErrTargetCrashed] and [context.DeadlineExceeded]
+// may succeed on a retry, and [ErrEngineClosed] means the engine is spent and a
+// new one is needed.
+//
+// [mermaid.js]: https://github.com/mermaid-js/mermaid
+// [chromedp]: https://github.com/chromedp/chromedp
 package mermaid_go
 
 import (
@@ -56,6 +77,13 @@ var (
 	// honour, rather than ignoring it. WithBundle is the only such option: it
 	// embeds the source in the SVG's <desc>, which a PNG has nowhere to put.
 	ErrUnsupportedOption = errors.New("unsupported render option")
+	// ErrEngineClosed reports that the engine's own context is done, because
+	// Cancel was called or the context given to NewRenderEngine was cancelled.
+	// Both that and a cancelled caller otherwise surface as an indistinguishable
+	// context.Canceled, yet they call for opposite responses: a cancelled caller
+	// is routine and the engine is still good, whereas a closed engine will fail
+	// every subsequent render until a new one is built.
+	ErrEngineClosed = errors.New("render engine is closed")
 )
 
 type BoxModel = dom.BoxModel
@@ -117,7 +145,15 @@ func NewRenderEngine(ctx context.Context, statements []string, options ...chrome
 
 	actions := []chromedp.Action{
 		chromedp.Navigate(DefaultPage),
-		chromedp.Evaluate(SourceMermaid, nil),
+		// Evaluate asks for results by value unless handed a
+		// **runtime.RemoteObject, so it would serialise the bundle's completion
+		// value -- some 23KB of object graph -- and ship it over the websocket
+		// only for it to be discarded here. Decline it instead. Overriding the
+		// option is enough because Evaluate applies opts after its own default,
+		// and a nil res is ignored outright.
+		chromedp.Evaluate(SourceMermaid, nil, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+			return p.WithReturnByValue(false)
+		}),
 		chromedp.Evaluate("mermaid.initialize({startOnLoad:false})", nil),
 	}
 	for _, stmt := range statements {
@@ -193,8 +229,17 @@ func (r *RenderEngine) noteCrash(reason string) {
 	r.crashMu.Unlock()
 
 	if report {
-		handler(err)
+		reportCrash(handler, err)
 	}
+}
+
+// reportCrash shields chromedp's event goroutine from a panicking handler. The
+// handler runs on a goroutine the consumer does not own and cannot wrap in a
+// recover of their own, so a panic there would take the process down. There is
+// nowhere to report the panic to, so it is swallowed deliberately.
+func reportCrash(handler func(error), err error) {
+	defer func() { _ = recover() }()
+	handler(err)
 }
 
 func (r *RenderEngine) crashErrLocked() error {
@@ -272,7 +317,7 @@ func (r *RenderEngine) acquire(ctx context.Context) (release func(), err error) 
 	case <-ctx.Done():
 		return nil, r.renderErr(ctx, ctx.Err())
 	case <-r.ctx.Done():
-		return nil, r.annotateCrash(r.ctx.Err())
+		return nil, r.renderErr(ctx, r.ctx.Err())
 	}
 }
 
@@ -284,6 +329,11 @@ func (r *RenderEngine) renderErr(caller context.Context, err error) error {
 		if cause := context.Cause(caller); cause != nil {
 			err = cause
 		}
+	}
+	// Say so when the engine itself is what ended the render, since the caller
+	// has to build a new engine rather than simply retry.
+	if r.ctx.Err() != nil {
+		err = fmt.Errorf("%w: %w", ErrEngineClosed, err)
 	}
 	return r.annotateCrash(err)
 }

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -376,12 +376,20 @@ func BenchmarkRenderEngine_Render(b *testing.B) {
     A-->C;
     B-->D;
     C-->D;`
-	ctx1 := context.Background()
-	re1, _ := NewRenderEngine(ctx1, nil)
-	for i := 0; i < b.N; i++ {
-		_, _ = re1.Render(case1)
+	// Both errors used to be discarded, so a browser that would not start
+	// panicked on the nil engine, and a failing render was timed as if it had
+	// succeeded.
+	re1, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		b.Fatalf("NewRenderEngine() error = %v", err)
 	}
-	re1.Cancel()
+	defer re1.Cancel()
+
+	for b.Loop() {
+		if _, err := re1.Render(case1); err != nil {
+			b.Fatalf("Render() error = %v", err)
+		}
+	}
 }
 
 func TestRenderEngine_RenderTimeout(t *testing.T) {
@@ -826,4 +834,78 @@ func TestRenderEngine_StartupDiagnostics(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRenderEngine_ErrEngineClosed(t *testing.T) {
+	re, err := NewRenderEngine(context.Background(), nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		t.Fatalf("NewRenderEngine() error = %v", err)
+	}
+
+	// A cancelled caller against a healthy engine is routine: it must not be
+	// reported as the engine being spent.
+	cancelledCtx, cancelCaller := context.WithCancel(context.Background())
+	cancelCaller()
+	if _, err := re.RenderContext(cancelledCtx, "graph TD; A-->B;"); errors.Is(err, ErrEngineClosed) {
+		t.Errorf("RenderContext() with a cancelled caller = %v, should not report ErrEngineClosed", err)
+	}
+
+	re.Cancel()
+
+	// Every entry point must agree once the engine is gone.
+	if _, err := re.Render("graph TD; A-->B;"); !errors.Is(err, ErrEngineClosed) {
+		t.Errorf("Render() after Cancel() = %v, want ErrEngineClosed", err)
+	}
+	if _, err := re.RenderContext(context.Background(), "graph TD; A-->B;"); !errors.Is(err, ErrEngineClosed) {
+		t.Errorf("RenderContext() after Cancel() = %v, want ErrEngineClosed", err)
+	}
+	if _, _, err := re.RenderAsPng("graph TD; A-->B;"); !errors.Is(err, ErrEngineClosed) {
+		t.Errorf("RenderAsPng() after Cancel() = %v, want ErrEngineClosed", err)
+	}
+
+	// The underlying cause stays visible; only the interpretation is added.
+	_, err = re.Render("graph TD; A-->B;")
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Render() after Cancel() = %v, want the underlying context.Canceled preserved", err)
+	}
+}
+
+func TestRenderEngine_ClosedEngineOutlivesParentContext(t *testing.T) {
+	// Cancelling the context handed to NewRenderEngine kills the engine just as
+	// Cancel does, and must be reported the same way.
+	ctx, cancel := context.WithCancel(context.Background())
+	re, err := NewRenderEngine(ctx, nil, chromedp.WSURLReadTimeout(renderTimeout))
+	if err != nil {
+		t.Fatalf("NewRenderEngine() error = %v", err)
+	}
+	defer re.Cancel()
+
+	cancel()
+	if _, err := re.Render("graph TD; A-->B;"); !errors.Is(err, ErrEngineClosed) {
+		t.Errorf("Render() after the parent context was cancelled = %v, want ErrEngineClosed", err)
+	}
+}
+
+func TestReportCrash_ContainsPanic(t *testing.T) {
+	// The handler runs on chromedp's event goroutine, where a panic would take
+	// the process down with no way for the consumer to recover it.
+	re := &RenderEngine{}
+	re.SetTargetCrashedHandler(func(error) { panic("handler blew up") })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		re.handleTargetEvent(&inspector.EventTargetCrashed{})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleTargetEvent did not return")
+	}
+
+	// The crash is still recorded even though the handler misbehaved.
+	if err := re.CrashError(); !errors.Is(err, ErrTargetCrashed) {
+		t.Errorf("CrashError() = %v, want the crash recorded despite the panic", err)
+	}
 }


### PR DESCRIPTION
Five small follow-ups to #72 and #74. Each was verified rather than assumed.

## `ErrEngineClosed`

A spent engine and a cancelled caller were byte-identical. Measured before the fix:

```
caller-cancelled: context canceled (Is Canceled=true)
engine-closed:    context canceled (Is Canceled=true)
distinguishable?  false
```

They call for opposite responses — a cancelled caller is routine and the engine is still good, whereas a closed engine will fail every subsequent render until a new one is built. #74 arguably widened this by making caller cancellation a routine outcome that looked exactly like a corpse. The error is now tagged when the engine's own context is done, with the underlying `context.Canceled` left intact underneath. It covers both `Cancel()` and the context passed to `NewRenderEngine` being cancelled.

## Stop shipping the bundle's completion value back

`chromedp.Evaluate` requests results by value unless handed a `**runtime.RemoteObject`, so every `NewRenderEngine` had V8 serialise the mermaid bundle's completion value and ship it over the websocket purely to be discarded here. Measured at **23,752 bytes** of JSON per engine creation.

Overriding the option is enough — `Evaluate` applies `opts` after its own default, and a `nil` res is ignored outright. Declining by-value rather than appending `;void 0;` also avoids copying the 3.5 MB source.

## Contain a panicking crash handler

`SetTargetCrashedHandler`'s callback runs on chromedp's event goroutine, which the consumer does not own and cannot wrap in a recover of their own — so a panic there took the whole process down. Now recovered. There is nowhere to report it to, so it is swallowed deliberately, and both the doc comment and the README say so.

## Package doc comment

Missing entirely, so pkg.go.dev had nothing to show for a public library. Added, covering the engine lifecycle, why the context-aware methods matter on a server, and the error taxonomy.

## Benchmark

It discarded the constructor error — panicking on the nil engine if chrome would not start — and every render error, so it could report timings for a run that produced nothing but failures. Now fails loudly, and uses `b.Loop`.

## Verification

`go vet` and `gofmt` clean. New tests: `ErrEngineClosed` across all entry points and via a cancelled parent context, a cancelled caller *not* being reported as a closed engine, and a panicking handler being contained with the crash still recorded.

Full-suite runs on my machine are currently unreliable for environmental reasons — it is sitting at load ~115 with 2 GB of 15 GB free, so Chrome instances get OOM-killed mid-suite (subtests that fail in the suite pass in isolation, and no chrome processes leak). I am relying on CI for the clean-environment signal, as with #72.

One incidental benefit visible in those failures: the diagnostic went from a bare `context canceled` to `render engine is closed: context canceled`, which is exactly the distinction this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
