### PR TITLE
feat: render without a browser through merman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
   ci-unit-tests:
     name: ci-unit-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v7
@@ -47,9 +47,38 @@ jobs:
       uses: browser-actions/setup-chrome@v2
       with:
         chrome-version: stable
-      
+
+    - name: Allow Chrome's sandbox (AppArmor restricts unprivileged userns on newer images)
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
+    # The merman backend renders through this binary. Without it the tests that
+    # exercise a real merman skip, and only the fake-binary tests run.
+    #
+    # Pinned to the 0.8 prerelease rather than 0.7.0, the current stable: 0.8 is
+    # the generation that answers `capabilities --json`, so the engine's probe is
+    # exercised on its real path here. The fallback 0.7.0 takes is covered by the
+    # scripted binary in the tests.
+    - name: Install merman-cli
+      env:
+        MERMAN_VERSION: v0.8.0-alpha.6
+        MERMAN_TARGET: x86_64-unknown-linux-gnu
+      run: |
+        set -euo pipefail
+        workdir="$(mktemp -d)"
+        cd "$workdir"
+        tarball="merman-cli-${MERMAN_TARGET}.tar.xz"
+        base="https://github.com/Latias94/merman/releases/download/${MERMAN_VERSION}"
+        curl -fsSLO "${base}/${tarball}"
+        curl -fsSLO "${base}/${tarball}.sha256"
+        sha256sum -c "${tarball}.sha256"
+        tar -xJf "${tarball}"
+        mkdir -p "$HOME/.local/bin"
+        install -m755 "merman-cli-${MERMAN_TARGET}/merman-cli" "$HOME/.local/bin/merman-cli"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        rm -rf "$workdir"
+
     - name: Run unit tests
-      run:  go test ./...
+      run:  go test -v ./...
 
   ci-build-example:
     name: ci-build-example

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 It works by leveraging [chromedp](https://github.com/chromedp/chromedp) to run a headless Chrome/Chromium instance, providing a robust and accurate rendering environment for all Mermaid diagram types.
 
+For deployments where a browser is unwelcome, a second backend renders through [merman][], a native
+Rust implementation of Mermaid — see [Rendering without a browser](#rendering-without-a-browser).
+
 ## Prerequisites
 
-Since this library uses `chromedp`, you must have **Google Chrome** or **Chromium** installed on your system.
+The default backend uses `chromedp`, so you must have **Google Chrome** or **Chromium** installed on
+your system. The merman backend needs neither: it requires only the `merman-cli` binary on `PATH`.
 
 ## Installation
 
@@ -122,13 +126,31 @@ matching on messages — which matters mainly for deciding whether a retry is wo
 
 | Error | Meaning | Retry? |
 | --- | --- | --- |
-| `ErrRenderException` | The page raised a JavaScript exception; almost always an invalid diagram. The `*runtime.ExceptionDetails` stays reachable via `errors.As` for the script location and stack. | No — it will fail identically |
+| `ErrRenderException` | The backend rejected the diagram source. Both backends use it, and each leaves its own detail reachable via `errors.As`: Chrome a `*runtime.ExceptionDetails` (it raises a genuine JavaScript exception, with the script location and stack), merman a `*MermanExitError`. | No — it will fail identically |
 | `ErrTargetCrashed` | Chrome died. Joined to the underlying error, and reported to `SetTargetCrashedHandler`. | Yes, on a fresh engine |
 | `context.DeadlineExceeded` | The render, or the wait for a turn, outran its deadline. | Maybe |
 | `ErrUnsupportedOption` | A `RenderOption` the called method cannot honour, e.g. `WithBundle()` on a PNG. | No — fix the call |
 | `ErrFailedEncoding` | The diagram source could not be JSON-encoded. Wraps the underlying error. | No |
 | `ErrMermaidNotReady` | `mermaid.js` did not initialise. The message names what `typeof mermaid` actually was. | No |
 | `ErrEngineClosed` | The engine's context is done, because `Cancel()` was called or the context passed to `NewRenderEngine` was cancelled. Without it this is indistinguishable from a cancelled caller, yet it needs the opposite response. | No — build a new engine |
+
+The merman backend reports the same `ErrRenderException`, `ErrUnsupportedOption`,
+`ErrEngineClosed` and `context.DeadlineExceeded`, plus three of its own:
+
+| Error | Meaning | Retry? |
+| --- | --- | --- |
+| `ErrMermanUnavailable` | The `merman-cli` binary was not found, or could not answer the capability probe. Only `NewMermanEngine` returns it. | No — fix the installation |
+| `ErrMermanCapability` | The binary was built without a feature the call needs, e.g. PNG output. | No — install a different build |
+| `ErrMermanFailed` | merman failed for a reason other than an invalid diagram: a rejected command line, an unusable configuration file, an operational failure, or unusable output. Carries its stderr. | Maybe |
+
+`errors.As` recovers a `*MermanExitError` (`Bin`, `Code`, `Stderr`) whenever a merman process is what
+failed. It is worth reaching for, because the exit codes do not partition failures perfectly on every
+release: 0.7.0 exits 1 for a missing or malformed configuration file as well as for an invalid
+diagram, and only the status and the diagnostics tell those apart. 0.8 fixed that — configuration
+errors moved to exit 2 — but the status stays exposed rather than assumed. `NewMermanEngine` reads the file
+given to `WithMermanConfigFile` up front for exactly that reason — so the mistake it *can* catch
+fails once, honestly, instead of making every render look like a bad diagram. A file smuggled in
+through `WithMermanArgs` is still merman's to reject.
 
 ## Example
 
@@ -175,6 +197,95 @@ func main() {
 }
 ```
 
+## Rendering without a browser
+
+[merman][] is a native (Rust) implementation of Mermaid that parses, lays out and renders diagrams
+without a browser or a JavaScript runtime. `NewMermanEngine` drives its CLI, so an engine costs one
+capability probe to start instead of a Chrome launch, and a deployment needs only the `merman-cli`
+binary — no Chrome, no `mermaid.js` bundle.
+
+Bear in mind that merman is a *reimplementation* of Mermaid, not Mermaid itself: it targets a pinned
+Mermaid baseline (`MermaidVersion()` reports which) and its SVG is not byte-identical to the browser
+backend's. `NewRenderEngine` remains the reference implementation.
+
+```go
+re, err := mermaid_go.NewMermanEngine(context.Background())
+if err != nil {
+    panic(err) // e.g. errors.Is(err, mermaid_go.ErrMermanUnavailable): merman-cli is not installed
+}
+defer re.Cancel()
+
+svg, err := re.Render("graph TD; A-->B;", mermaid_go.WithBundle())
+```
+
+Both engines satisfy the `Renderer` interface — `Render`, `RenderAsPng`, `RenderAsScaledPng`, their
+`Context` variants, `SetRenderTimeout` and `Cancel` — so a program can choose a backend at startup
+and pass the result around:
+
+```go
+var re mermaid_go.Renderer
+if *noBrowser {
+    re, err = mermaid_go.NewMermanEngine(ctx)
+} else {
+    re, err = mermaid_go.NewRenderEngine(ctx, nil)
+}
+```
+
+Chrome's crash reporting (`SetTargetCrashedHandler`, `CrashError`) stays off the interface, as does
+merman's `Version`/`MermaidVersion`/`Binary`/`Capabilities`; nothing corresponds on the other side.
+
+### `NewMermanEngine(ctx context.Context, opts ...MermanOption) (*MermanEngine, error)`
+
+Locates the binary and asks it what it is, so a missing or unusable install fails here rather than
+on the first render. As with `NewRenderEngine`, `ctx` governs the engine's **whole lifetime**: the
+engine context is derived from it, so a deadline on `ctx` does not merely bound start-up — when it
+passes, the engine closes and every later render fails with `ErrEngineClosed`. Prefer
+`context.Background()` for a long-lived engine and let each render carry its own deadline; use
+`WithMermanStartupTimeout` to bound only the probe.
+
+| Option | Effect |
+| --- | --- |
+| `WithMermanBinary(path)` | The executable to run, as a path or a name on `PATH`. Default: `merman-cli`, then `merman`. |
+| `WithMermanSvgID(id)` | Root `<svg>` id and marker prefix. Default `"mermaid"`, matching the browser backend. |
+| `WithMermanTheme(name)` | Mermaid theme, the equivalent of a `mermaid.initialize({theme: ...})` statement. |
+| `WithMermanConfigFile(path)` | JSON Mermaid configuration file — the closest equivalent to `NewRenderEngine`'s `statements`, which have no JavaScript context to run in here. Read and checked for well-formed JSON at construction. |
+| `WithMermanArgs(args...)` | Extra arguments appended to every render, for the parts of merman's command line this package does not model (resource profiles, icon packs, layout viewport). |
+| `WithMermanConcurrency(n)` | How many merman processes may run at once. Default: `GOMAXPROCS`. |
+| `WithMermanStartupTimeout(d)` | Bounds the capability probe when `ctx` has no deadline. Default: `DefaultStartupTimeout`. |
+
+### merman versions
+
+Tested against both generations. CI pins **0.8.0-alpha.6**, whose Mermaid baseline is 11.17.2, and
+**0.7.0**, the current stable release, is supported through the probe's fallback path. Note that the
+0.8 linux binaries need glibc 2.38 or newer — 0.7.0's run on older distributions.
+
+The probe prefers `capabilities --json`, which is authoritative about the compiled feature set, and
+falls back to `--version` on releases that predate that command — 0.7.0 among them. Those releases
+accept every argument this package builds and render identically; all the fallback gives up is the
+catalogue, so `Capabilities()` returns `nil` (unknown, not empty) and `MermaidVersion()` is empty.
+A `nil` catalogue is never read as *absent*: `RenderAsPng` attempts the render and lets merman
+answer, rather than refusing on a promise the binary never made.
+
+The two generations also differ in what an exit status means, which is why `MermanExitError` exposes
+it rather than this package inferring from it: 0.7.0 exits 1 for a bad configuration file, the same
+status as an invalid diagram, while 0.8 moved configuration errors to 2 and left 1 to mean invalid
+content alone.
+
+### Differences from the browser backend
+
+- **Concurrency.** Renders are separate processes, so they run in parallel up to
+  `WithMermanConcurrency`, rather than being serialised onto one browser tab. The wait for a slot is
+  still covered by the caller's context.
+- **Timeouts.** `SetRenderTimeout` and `WithTimeout` work the same way, enforced by killing the
+  process. A timed-out render does not invalidate the engine.
+- **PNG.** `RenderAsScaledPng` maps to merman's `--scale`. The returned `*BoxModel` is derived from
+  the image — width and height only, in CSS pixels as Chrome reports them (the image's pixel size
+  divided by `scale`) — because merman reports no layout box.
+- **`WithBundle()`.** The source is spliced into the SVG's `<desc>` here rather than through the DOM;
+  the result is the same, and it is still rejected for PNG with `ErrUnsupportedOption`.
+- **PDF, JPEG, ASCII.** merman can produce these, but this package exposes only SVG and PNG. Reach
+  for `merman-cli` directly if you need the rest.
+
 ## How to build locally
 
 1. Checkout the code base:
@@ -184,13 +295,21 @@ func main() {
 3. Run tests:
    `go test -v ./...`
 
+   The merman tests run against a scripted stand-in binary, so they need nothing installed. The
+   subtests that exercise a *real* merman (`TestMermanEngine_LiveRender`, `TestMermanEngine_LivePng`)
+   skip unless `merman-cli` is on `PATH` — CI installs it, and locally the
+   [release binaries](https://github.com/Latias94/merman/releases) or `cargo install merman-cli` will
+   do.
+
 ## License
 
 - [mermaid.go][]: MIT License
 - [mermaid.js][]: MIT License
 - [chromedp]: MIT License
+- [merman][]: optional, invoked as an external binary; see its repository for terms
  
 [mermaid.go]: https://github.com/dreampuf/mermaid.go
+[merman]: https://github.com/Latias94/merman
 [mermaid.js]: https://mermaid-js.github.io/mermaid/
 [chromedp]: https://github.com/chromedp/chromedp
 

--- a/mermaid.go
+++ b/mermaid.go
@@ -1,6 +1,13 @@
 // Package mermaid_go renders [mermaid.js] diagrams to SVG and PNG from Go.
 //
-// It drives a headless Chrome through [chromedp]. NewRenderEngine launches the
+// Two backends render the same diagrams and satisfy the same [Renderer]
+// interface. NewRenderEngine drives mermaid.js itself in a headless Chrome, and
+// is the reference: whatever mermaid.js can draw, it draws. [NewMermanEngine]
+// instead runs the [merman] CLI, a native reimplementation, which removes the
+// browser dependency entirely at the cost of being a separate implementation of
+// mermaid rather than mermaid itself.
+//
+// The chrome backend drives Chrome through [chromedp]. NewRenderEngine launches the
 // browser once and loads the embedded mermaid.js bundle into a page; each render
 // then reuses that page, so the browser is started once rather than per diagram.
 // An engine owns operating system resources and must be released with
@@ -12,13 +19,14 @@
 //
 // Failures are classified with sentinel errors so callers can branch with
 // [errors.Is] rather than on messages, which mainly decides whether a retry is
-// worthwhile: [ErrRenderException] means the diagram is invalid and will fail
+// worthwhile: [ErrRenderException] means the diagram was rejected and will fail
 // identically next time, whereas [ErrTargetCrashed] and [context.DeadlineExceeded]
 // may succeed on a retry, and [ErrEngineClosed] means the engine is spent and a
 // new one is needed.
 //
 // [mermaid.js]: https://github.com/mermaid-js/mermaid
 // [chromedp]: https://github.com/chromedp/chromedp
+// [merman]: https://github.com/Latias94/merman
 package mermaid_go
 
 import (
@@ -66,13 +74,18 @@ var (
 	// against a crashed target fail with this error joined to the underlying
 	// chromedp error.
 	ErrTargetCrashed = errors.New("chrome target crashed")
-	// ErrRenderException reports that the page raised a JavaScript exception,
-	// which for a render almost always means the diagram source is invalid.
+	// ErrRenderException reports that the backend rejected the diagram source.
 	// It is worth separating from the transport and lifecycle failures: retrying
 	// it will fail identically, whereas retrying ErrTargetCrashed or a timeout
-	// may well succeed. The *runtime.ExceptionDetails chrome supplied stays
-	// reachable with errors.As for the script location and stack.
-	ErrRenderException = errors.New("render raised a javascript exception")
+	// may well succeed.
+	//
+	// Both backends use it, and each keeps its own detail reachable with
+	// errors.As: chrome raises a JavaScript exception and leaves the
+	// *runtime.ExceptionDetails for the script location and stack, while merman
+	// exits 1 and leaves a *MermanExitError. Only chrome's detail is a genuine
+	// exception, and only merman's status is imperfectly exclusive to the
+	// diagram -- see MermanExitError.
+	ErrRenderException = errors.New("render rejected the diagram source")
 	// ErrUnsupportedOption reports a RenderOption that the called method cannot
 	// honour, rather than ignoring it. WithBundle is the only such option: it
 	// embeds the source in the SVG's <desc>, which a PNG has nowhere to put.
@@ -308,74 +321,38 @@ func WithTimeout(d time.Duration) RenderOption {
 // unbounded queue of other renders with no way out, because the per-render
 // deadline only starts once a render actually begins.
 func (r *RenderEngine) acquire(ctx context.Context) (release func(), err error) {
-	if err := ctx.Err(); err != nil {
+	release, err = waitForSlot(ctx, r.ctx, r.sem)
+	if err != nil {
 		return nil, r.renderErr(ctx, err)
 	}
-	select {
-	case r.sem <- struct{}{}:
-		return func() { <-r.sem }, nil
-	case <-ctx.Done():
-		return nil, r.renderErr(ctx, ctx.Err())
-	case <-r.ctx.Done():
-		return nil, r.renderErr(ctx, r.ctx.Err())
-	}
+	return release, nil
 }
 
-// renderErr classifies a failed render. When the caller's context is what ended
-// it, the derived context reports a bare Canceled; the caller's own cause says
-// why, so prefer it.
+// renderErr classifies a failed render: the lifecycle labels every backend
+// applies, plus the crash annotation only chrome can supply.
 func (r *RenderEngine) renderErr(caller context.Context, err error) error {
-	if errors.Is(err, context.Canceled) {
-		if cause := context.Cause(caller); cause != nil {
-			err = cause
-		}
-	}
-	// Say so when the engine itself is what ended the render, since the caller
-	// has to build a new engine rather than simply retry.
-	if r.ctx.Err() != nil {
-		err = fmt.Errorf("%w: %w", ErrEngineClosed, err)
-	}
-	return r.annotateCrash(err)
+	return r.annotateCrash(classifyRenderErr(caller, r.ctx, err))
 }
 
-// renderContext derives the context for one render. It is rooted at the engine
-// context because that is what carries chromedp's target; the caller's context
-// contributes its deadline and its cancellation, but not its values.
+// renderContext derives the context for one render, applying whichever of the
+// engine's timeout, this call's WithTimeout and the caller's deadline lands
+// first. See deriveRenderContext for how the two contexts are combined.
 //
 // Cancelling a context derived from the engine context only aborts the in-flight
 // commands, so the engine stays usable after a timeout. This is not true of the
 // very first Run against a fresh engine, which is why NewRenderEngine allocates
 // the browser separately -- see the comment there.
 func (r *RenderEngine) renderContext(caller context.Context, opts *renderOptions) (context.Context, context.CancelFunc) {
-	timeout := time.Duration(r.renderTimeout.Load())
+	return deriveRenderContext(r.ctx, caller, r.effectiveTimeout(opts))
+}
+
+// effectiveTimeout is the per-render deadline this call asked for, defaulting to
+// the engine's. A value <= 0 means no deadline of our own.
+func (r *RenderEngine) effectiveTimeout(opts *renderOptions) time.Duration {
 	if opts.hasTimeout {
-		timeout = opts.timeout
+		return opts.timeout
 	}
-
-	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-	)
-	// Honour whichever of the two deadlines lands first, so a caller asking for
-	// less than the engine's timeout gets a truthful DeadlineExceeded rather
-	// than the bare Canceled that propagation alone would produce.
-	deadline, hasDeadline := caller.Deadline()
-	switch {
-	case timeout > 0 && hasDeadline && time.Now().Add(timeout).Before(deadline):
-		ctx, cancel = context.WithTimeout(r.ctx, timeout)
-	case hasDeadline:
-		ctx, cancel = context.WithDeadline(r.ctx, deadline)
-	case timeout > 0:
-		ctx, cancel = context.WithTimeout(r.ctx, timeout)
-	default:
-		ctx, cancel = context.WithCancel(r.ctx)
-	}
-
-	stop := context.AfterFunc(caller, cancel)
-	return ctx, func() {
-		stop()
-		cancel()
-	}
+	return time.Duration(r.renderTimeout.Load())
 }
 
 // annotateCrash classifies a render failure so callers can act on it without

--- a/merman.go
+++ b/merman.go
@@ -1,0 +1,698 @@
+package mermaid_go
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"image/png"
+	"math"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/chromedp/cdproto/dom"
+)
+
+// MermanBinaries are the names NewMermanEngine looks for on PATH, in order,
+// when no binary is named with WithMermanBinary. merman ships the renderer as
+// merman-cli; the shorter name is accepted for a locally built or renamed copy.
+var MermanBinaries = []string{"merman-cli", "merman"}
+
+// DefaultMermanSvgID is the id given to the root <svg> element, matching the id
+// mermaid.js gives it under the chrome backend so a diagram styled or scripted
+// against one backend keeps working under the other.
+const DefaultMermanSvgID = "mermaid"
+
+var (
+	// ErrMermanUnavailable reports that the merman binary could not be found or
+	// could not describe itself. The engine refuses to start rather than
+	// deferring the failure to the first render.
+	ErrMermanUnavailable = errors.New("merman binary unavailable")
+	// ErrMermanCapability reports that the merman binary was built without a
+	// feature the call needs -- most often PNG output, which is a compile-time
+	// feature of the CLI rather than something every build has. It is separated
+	// from ErrMermanFailed because the fix is to install a different binary, not
+	// to change the diagram or retry.
+	ErrMermanCapability = errors.New("merman binary lacks a required capability")
+	// ErrMermanFailed reports a merman invocation that failed for a reason other
+	// than an invalid diagram: a rejected command line, an unusable configuration
+	// file, an operational failure, or output this package could not use. The
+	// binary's stderr is included, and a *MermanExitError carrying the exit status
+	// is reachable with errors.As when a process is what failed.
+	ErrMermanFailed = errors.New("merman render failed")
+)
+
+// MermanEngine renders diagrams by running the merman CLI, which parses, lays
+// out and renders mermaid natively. It is an alternative to [RenderEngine]:
+// there is no browser and no JavaScript, so nothing has to be installed beyond
+// the merman binary itself, and start-up costs nothing but one capability probe.
+//
+// Unlike [RenderEngine], which serialises everything onto one browser tab, each
+// render is its own short-lived process, so renders run concurrently up to the
+// limit set by [WithMermanConcurrency]. An engine holds no operating system
+// resources between renders, but [MermanEngine.Cancel] still exists to abort
+// renders in flight and to make every later render fail with [ErrEngineClosed],
+// so both backends can be shut down the same way.
+//
+// Output is merman's own, not mermaid.js's. It aims to match mermaid but is a
+// separate implementation, so the two backends do not produce byte-identical
+// SVG; see the merman project for the compatibility it claims.
+type MermanEngine struct {
+	bin  string
+	args []string
+	// sem bounds how many merman processes run at once. As in RenderEngine it is
+	// a channel rather than a semaphore type so that waiting for a turn can be
+	// abandoned when the caller's context is cancelled.
+	sem    chan struct{}
+	ctx    context.Context
+	cancel context.CancelFunc
+	// renderTimeout is atomic so it can be adjusted while a render is running.
+	renderTimeout atomic.Int64
+
+	version string
+	mermaid string
+	// capabilities is the catalogue the binary reported, or nil when it is an
+	// older release with no `capabilities` command to ask. Nil means unknown,
+	// not empty: the engine must not conclude a format is missing from it.
+	capabilities map[string]bool
+}
+
+type mermanConfig struct {
+	bin            string
+	svgID          string
+	theme          string
+	configFile     string
+	args           []string
+	concurrency    int
+	startupTimeout time.Duration
+}
+
+// MermanOption configures a MermanEngine at construction.
+type MermanOption func(*mermanConfig)
+
+// WithMermanBinary names the merman executable to run, as a path or as a name
+// to look up on PATH. Without it NewMermanEngine tries each of MermanBinaries.
+func WithMermanBinary(path string) MermanOption {
+	return func(c *mermanConfig) { c.bin = path }
+}
+
+// WithMermanSvgID overrides DefaultMermanSvgID as the root <svg> element's id
+// and internal marker prefix. An empty id leaves merman's default in place.
+func WithMermanSvgID(id string) MermanOption {
+	return func(c *mermanConfig) { c.svgID = id }
+}
+
+// WithMermanTheme selects a mermaid theme, the equivalent of passing
+// mermaid.initialize({theme: ...}) as a statement to NewRenderEngine.
+func WithMermanTheme(theme string) MermanOption {
+	return func(c *mermanConfig) { c.theme = theme }
+}
+
+// WithMermanConfigFile points merman at a JSON mermaid configuration file. It is
+// the closest equivalent to NewRenderEngine's statements, which cannot carry
+// over because there is no JavaScript context to run them in. The file is read
+// and checked for well-formed JSON by NewMermanEngine, which fails with
+// ErrMermanFailed rather than leaving every render to fail as a bad diagram.
+func WithMermanConfigFile(path string) MermanOption {
+	return func(c *mermanConfig) { c.configFile = path }
+}
+
+// WithMermanArgs appends arguments to every render invocation, for the parts of
+// merman's command line this package does not model -- resource profiles, icon
+// packs, layout viewport sizes and the like. They are appended last, so they
+// override the arguments built from the other options.
+func WithMermanArgs(args ...string) MermanOption {
+	return func(c *mermanConfig) { c.args = append(c.args, args...) }
+}
+
+// WithMermanConcurrency bounds how many merman processes may run at once,
+// defaulting to GOMAXPROCS. Renders beyond the limit wait for a turn, and that
+// wait is covered by the caller's context just as the render itself is. A value
+// <= 0 restores the default.
+func WithMermanConcurrency(n int) MermanOption {
+	return func(c *mermanConfig) { c.concurrency = n }
+}
+
+// WithMermanStartupTimeout bounds the capability probe NewMermanEngine runs when
+// the supplied context has no deadline of its own, defaulting to
+// DefaultStartupTimeout.
+func WithMermanStartupTimeout(d time.Duration) MermanOption {
+	return func(c *mermanConfig) { c.startupTimeout = d }
+}
+
+// mermanCapabilityDocument is the part of `merman-cli capabilities --json` this
+// package reads. The CLI compiles its output formats in as features, so a build
+// without PNG support is a real possibility that is better reported at start-up
+// than as a puzzling exit status on the first RenderAsPng.
+//
+// The command arrived after 0.7.0, so its absence is not a failure; see
+// probeMerman.
+type mermanCapabilityDocument struct {
+	Package struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"package"`
+	Compatibility struct {
+		Mermaid string `json:"mermaid"`
+	} `json:"compatibility"`
+	Commands     []string `json:"commands"`
+	Capabilities []struct {
+		ID string `json:"id"`
+	} `json:"capabilities"`
+}
+
+// NewMermanEngine builds an engine backed by the merman CLI. It locates the
+// binary and asks it what it is, so a missing or unusable binary is reported
+// here rather than on the first render.
+//
+// ctx governs the engine's whole lifetime, as it does for NewRenderEngine: the
+// engine context is derived from it, so a deadline on ctx does far more than
+// bound start-up -- when it passes, the engine closes and every later render
+// fails with ErrEngineClosed. For a long-lived engine prefer context.Background()
+// and let each render carry its own deadline; to bound only the probe, pass
+// WithMermanStartupTimeout.
+func NewMermanEngine(ctx context.Context, opts ...MermanOption) (*MermanEngine, error) {
+	cfg := &mermanConfig{
+		svgID:          DefaultMermanSvgID,
+		concurrency:    runtime.GOMAXPROCS(0),
+		startupTimeout: DefaultStartupTimeout,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.concurrency <= 0 {
+		cfg.concurrency = runtime.GOMAXPROCS(0)
+	}
+
+	if cfg.configFile != "" {
+		if err := checkMermanConfigFile(cfg.configFile); err != nil {
+			return nil, err
+		}
+	}
+
+	bin, err := lookMerman(cfg.bin)
+	if err != nil {
+		return nil, err
+	}
+
+	probeCtx := ctx
+	if _, ok := ctx.Deadline(); !ok && cfg.startupTimeout > 0 {
+		var cancel context.CancelFunc
+		probeCtx, cancel = context.WithTimeout(ctx, cfg.startupTimeout)
+		defer cancel()
+	}
+	probe, err := probeMerman(probeCtx, bin)
+	if err != nil {
+		return nil, err
+	}
+	// Only refuse on a catalogue the binary actually reported. A release too old
+	// to have `capabilities` renders perfectly well, and rejecting it for saying
+	// nothing would be worse than the puzzle the probe exists to prevent.
+	if probe.capabilities != nil && (!probe.commands["render"] || !probe.capabilities["svg"]) {
+		return nil, fmt.Errorf("%w: %s cannot render SVG", ErrMermanCapability, bin)
+	}
+
+	engine := &MermanEngine{
+		bin:          bin,
+		args:         mermanRenderArgs(cfg),
+		sem:          make(chan struct{}, cfg.concurrency),
+		version:      probe.version,
+		mermaid:      probe.mermaid,
+		capabilities: probe.capabilities,
+	}
+	engine.ctx, engine.cancel = context.WithCancel(ctx)
+	engine.renderTimeout.Store(int64(DefaultRenderTimeout))
+	return engine, nil
+}
+
+// checkMermanConfigFile reads the configuration merman is to be pointed at. A
+// missing or malformed file makes merman exit 1 -- the status it also uses for an
+// invalid diagram -- so without this every render would fail as
+// ErrRenderException and blame the diagram for a configuration mistake. Reading
+// it once at construction turns that into a single honest error instead.
+func checkMermanConfigFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("%w: configuration file: %w", ErrMermanFailed, err)
+	}
+	if !json.Valid(data) {
+		return fmt.Errorf("%w: configuration file %s is not valid JSON", ErrMermanFailed, path)
+	}
+	return nil
+}
+
+// lookMerman resolves the executable, naming everything it tried so a PATH
+// problem is obvious from the error alone.
+func lookMerman(bin string) (string, error) {
+	if bin != "" {
+		path, err := exec.LookPath(bin)
+		if err != nil {
+			return "", fmt.Errorf("%w: %w", ErrMermanUnavailable, err)
+		}
+		return path, nil
+	}
+	var errs []error
+	for _, name := range MermanBinaries {
+		path, err := exec.LookPath(name)
+		if err == nil {
+			return path, nil
+		}
+		errs = append(errs, err)
+	}
+	return "", fmt.Errorf("%w: none of %s found on PATH: %w",
+		ErrMermanUnavailable, strings.Join(MermanBinaries, ", "), errors.Join(errs...))
+}
+
+// mermanProbe is what NewMermanEngine could learn about the binary before
+// rendering anything with it.
+type mermanProbe struct {
+	version string
+	mermaid string
+	// commands and capabilities are nil unless the binary reported a catalogue.
+	commands     map[string]bool
+	capabilities map[string]bool
+}
+
+// probeMerman identifies the binary. It prefers `capabilities --json`, which is
+// authoritative about the compiled feature set, and falls back to --version for
+// releases that predate that command -- 0.7.0, the current stable, among them.
+// Those releases accept every argument this package builds and render exactly
+// the same, so all the fallback gives up is the catalogue, and the engine then
+// declines to guess rather than refusing to start.
+//
+// The fallback is deliberately narrow: it applies when the CLI rejects the
+// command as a usage error, not when it accepts and fails it. A binary that
+// knows `capabilities` and cannot answer it is broken, and that is worth
+// failing on here rather than at the first render.
+func probeMerman(ctx context.Context, bin string) (*mermanProbe, error) {
+	stdout, capErr := runMermanProbe(ctx, bin, "capabilities", "--json")
+	if capErr == nil {
+		doc := &mermanCapabilityDocument{}
+		if err := json.Unmarshal(stdout, doc); err != nil {
+			return nil, fmt.Errorf("%w: %s reported unreadable capabilities: %w", ErrMermanUnavailable, bin, err)
+		}
+		probe := &mermanProbe{
+			version:      doc.Package.Version,
+			mermaid:      doc.Compatibility.Mermaid,
+			commands:     make(map[string]bool, len(doc.Commands)),
+			capabilities: make(map[string]bool, len(doc.Capabilities)),
+		}
+		for _, command := range doc.Commands {
+			probe.commands[command] = true
+		}
+		for _, capability := range doc.Capabilities {
+			probe.capabilities[capability.ID] = true
+		}
+		return probe, nil
+	}
+	if ctx.Err() != nil {
+		return nil, capErr
+	}
+	// Only a usage error means "this release has no such command". Anything else
+	// -- the command understood and failed, or the process refusing to start --
+	// is a broken or incompatible binary, and starting it blind would hide that
+	// until the first render.
+	if !mermanRejectedTheCommand(capErr) {
+		return nil, capErr
+	}
+
+	stdout, err := runMermanProbe(ctx, bin, "--version")
+	if err != nil {
+		// Report the --version failure: an old merman rejects `capabilities`
+		// too, so that error says nothing about whether the binary is usable.
+		return nil, err
+	}
+	return &mermanProbe{version: mermanVersion(stdout)}, nil
+}
+
+// mermanRejectedTheCommand reports whether the CLI answered with a usage error,
+// exit status 2, which is how a release that predates a subcommand says it does
+// not know it -- 0.7.0 answers `capabilities --json` exactly that way.
+func mermanRejectedTheCommand(err error) bool {
+	var exit *exec.ExitError
+	return errors.As(err, &exit) && exit.ExitCode() == 2
+}
+
+// runMermanProbe runs one identification command, folding the binary's stderr
+// into the error so a wrong or broken executable explains itself.
+func runMermanProbe(ctx context.Context, bin string, args ...string) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("%w: %s %s: %w", ErrMermanUnavailable, bin, strings.Join(args, " "), ctxErr)
+		}
+		return nil, fmt.Errorf("%w: %s %s: %w: %s",
+			ErrMermanUnavailable, bin, strings.Join(args, " "), err, mermanDiagnostic(stderr.Bytes()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// mermanVersion picks the version out of `merman-cli 0.7.0`.
+func mermanVersion(stdout []byte) string {
+	line, _, _ := strings.Cut(string(stdout), "\n")
+	if fields := strings.Fields(line); len(fields) > 0 {
+		return fields[len(fields)-1]
+	}
+	return ""
+}
+
+// mermanRenderArgs builds the arguments shared by every render: the ones fixed
+// by this package's contract (stdin in, stdout out, diagnostics on stderr only)
+// followed by the ones the caller configured.
+func mermanRenderArgs(cfg *mermanConfig) []string {
+	args := []string{"render", "-", "--output", "-", "--quiet"}
+	if cfg.svgID != "" {
+		args = append(args, "--svg-id", cfg.svgID)
+	}
+	if cfg.theme != "" {
+		args = append(args, "--theme", cfg.theme)
+	}
+	if cfg.configFile != "" {
+		args = append(args, "--config-file", cfg.configFile)
+	}
+	return append(args, cfg.args...)
+}
+
+// Version reports the version of the merman binary behind the engine.
+func (m *MermanEngine) Version() string { return m.version }
+
+// MermaidVersion reports the mermaid release merman's output is pinned to, the
+// counterpart of the embedded SourceMermaid bundle's version. It is empty when
+// the binary is too old to report one.
+func (m *MermanEngine) MermaidVersion() string { return m.mermaid }
+
+// Binary reports the resolved path of the merman executable.
+func (m *MermanEngine) Binary() string { return m.bin }
+
+// Capabilities reports the merman features the binary was compiled with, sorted
+// -- "svg", "png", "math" and so on, using merman's own ids. It is nil, rather
+// than empty, when the binary predates the `capabilities` command and so never
+// said: an engine on such a binary still renders, it just cannot promise a
+// format in advance.
+func (m *MermanEngine) Capabilities() []string {
+	if m.capabilities == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(m.capabilities))
+	for id := range m.capabilities {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// SetRenderTimeout overrides DefaultRenderTimeout for subsequent renders. A
+// value <= 0 disables the per-render deadline, leaving renders bounded only by
+// the engine context and the caller's own.
+func (m *MermanEngine) SetRenderTimeout(d time.Duration) {
+	m.renderTimeout.Store(int64(d))
+}
+
+// Cancel closes the engine: renders in flight are killed and every later render
+// fails with ErrEngineClosed. Calling it more than once is harmless.
+func (m *MermanEngine) Cancel() { m.cancel() }
+
+// Render renders content to SVG. It is equivalent to RenderContext with a
+// background context, so it cannot be cancelled by the caller and is bounded
+// only by the engine's render timeout.
+func (m *MermanEngine) Render(content string, opts ...RenderOption) (string, error) {
+	return m.RenderContext(context.Background(), content, opts...)
+}
+
+// RenderContext renders content to SVG, giving up if ctx is cancelled. The
+// context covers the wait for a concurrency slot as well as the render itself,
+// and its deadline applies if it is sooner than the engine's render timeout.
+// Only cancellation and the deadline are taken from ctx; its values are not.
+func (m *MermanEngine) RenderContext(ctx context.Context, content string, opts ...RenderOption) (string, error) {
+	renderOpts := &renderOptions{}
+	for _, opt := range opts {
+		opt(renderOpts)
+	}
+
+	out, err := m.run(ctx, renderOpts, content, nil)
+	if err != nil {
+		return "", err
+	}
+	svg := string(out)
+	if renderOpts.bundle {
+		return bundleSource(svg, content)
+	}
+	return svg, nil
+}
+
+// RenderAsPng renders content to a PNG. It is equivalent to RenderAsPngContext
+// with a background context.
+func (m *MermanEngine) RenderAsPng(content string, opts ...RenderOption) ([]byte, *BoxModel, error) {
+	return m.RenderAsScaledPngContext(context.Background(), content, 1.0, opts...)
+}
+
+// RenderAsPngContext renders content to a PNG, giving up if ctx is cancelled.
+func (m *MermanEngine) RenderAsPngContext(ctx context.Context, content string, opts ...RenderOption) ([]byte, *BoxModel, error) {
+	return m.RenderAsScaledPngContext(ctx, content, 1.0, opts...)
+}
+
+// RenderAsScaledPng renders content to a PNG at the given scale. It is
+// equivalent to RenderAsScaledPngContext with a background context.
+func (m *MermanEngine) RenderAsScaledPng(content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error) {
+	return m.RenderAsScaledPngContext(context.Background(), content, scale, opts...)
+}
+
+// RenderAsScaledPngContext renders content to a PNG at the given scale, giving
+// up if ctx is cancelled. See RenderContext for how ctx is applied. On failure
+// it returns no image and no box model, so a caller cannot mistake a partial
+// image for a complete one.
+//
+// The box model is derived from the image, since merman reports no layout box:
+// only the width and height are populated, in CSS pixels as chrome reports them
+// -- that is, the image's pixel size divided by scale -- and the quads describe
+// that box at the origin.
+func (m *MermanEngine) RenderAsScaledPngContext(ctx context.Context, content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error) {
+	renderOpts := &renderOptions{}
+	for _, opt := range opts {
+		opt(renderOpts)
+	}
+	if renderOpts.bundle {
+		return nil, nil, fmt.Errorf("%w: WithBundle has no effect on a PNG, the source is embedded in the SVG's <desc>", ErrUnsupportedOption)
+	}
+	// NaN and +Inf both compare false to <= 0, so they need naming: they would
+	// otherwise reach merman as "NaN"/"+Inf" and come back as a rejected command
+	// line rather than the unsupported scale this documents.
+	if math.IsNaN(scale) || math.IsInf(scale, 0) || scale <= 0 {
+		return nil, nil, fmt.Errorf("%w: scale must be a positive, finite number, got %v", ErrUnsupportedOption, scale)
+	}
+	// Only pre-empt the render when the binary said it cannot do this.
+	if m.capabilities != nil && !m.capabilities["png"] {
+		return nil, nil, fmt.Errorf("%w: %s was built without png output", ErrMermanCapability, m.bin)
+	}
+
+	args := []string{"--format", "png"}
+	if scale != 1 {
+		args = append(args, "--scale", strconv.FormatFloat(scale, 'f', -1, 64))
+	}
+	out, err := m.run(ctx, renderOpts, content, args)
+	if err != nil {
+		return nil, nil, err
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(out))
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %s returned an unreadable png: %w", ErrMermanFailed, m.bin, err)
+	}
+	return out, boxModelFor(float64(config.Width)/scale, float64(config.Height)/scale), nil
+}
+
+// run executes one merman invocation, with extra taking the arguments specific
+// to this render. It returns stdout, which carries the rendered payload and
+// nothing else -- merman keeps diagnostics on stderr.
+func (m *MermanEngine) run(caller context.Context, opts *renderOptions, content string, extra []string) ([]byte, error) {
+	release, err := m.acquire(caller)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	runCtx, cancel := deriveRenderContext(m.ctx, caller, m.effectiveTimeout(opts))
+	defer cancel()
+
+	args := make([]string, 0, len(m.args)+len(extra))
+	args = append(args, m.args...)
+	args = append(args, extra...)
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(runCtx, m.bin, args...)
+	cmd.Stdin = strings.NewReader(content)
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	// Killing the process on a deadline is not enough on its own: Wait also
+	// waits for the output pipes to close, which anything the render left behind
+	// would hold open. Give that a bound so a timed out render cannot outlive
+	// its deadline indefinitely.
+	cmd.WaitDelay = mermanWaitDelay
+	if err := cmd.Run(); err != nil {
+		return nil, m.runErr(caller, runCtx, err, stderr.Bytes())
+	}
+	return stdout.Bytes(), nil
+}
+
+func (m *MermanEngine) acquire(ctx context.Context) (release func(), err error) {
+	release, err = waitForSlot(ctx, m.ctx, m.sem)
+	if err != nil {
+		return nil, classifyRenderErr(ctx, m.ctx, err)
+	}
+	return release, nil
+}
+
+func (m *MermanEngine) effectiveTimeout(opts *renderOptions) time.Duration {
+	if opts.hasTimeout {
+		return opts.timeout
+	}
+	return time.Duration(m.renderTimeout.Load())
+}
+
+// MermanExitError reports how a merman invocation failed: the status it exited
+// with and the diagnostics it wrote. It is wrapped by whichever sentinel runErr
+// chose and stays reachable with errors.As, because merman's exit codes do not
+// partition failures perfectly -- releases up to 0.7.0 exit 1 for an unreadable
+// configuration file as well as for an invalid diagram -- so a caller who must be
+// certain can read the status and the message instead of trusting the sentinel.
+type MermanExitError struct {
+	// Bin is the executable that ran.
+	Bin string
+	// Code is its exit status: 1 for invalid content, 2 for a rejected command
+	// line, 3 for an operational failure.
+	Code int
+	// Stderr is what merman reported, trimmed and truncated.
+	Stderr string
+}
+
+func (e *MermanExitError) Error() string {
+	return fmt.Sprintf("%s exited %d: %s", e.Bin, e.Code, e.Stderr)
+}
+
+// runErr classifies a failed invocation. A killed process reports only "signal:
+// killed", so the context is consulted first: it knows whether the deadline
+// passed, the caller gave up or the engine was closed.
+//
+// Otherwise the exit status classifies it. Exit 1 is merman's status for invalid
+// mermaid or content, so it becomes the same non-retryable ErrRenderException an
+// invalid diagram raises under chrome. It is not exclusively that -- 0.7.0 also
+// exits 1 for a missing or malformed configuration file -- which is why
+// NewMermanEngine validates that file up front, leaving the diagram as the
+// explanation this package can still produce, and why MermanExitError keeps the
+// raw status reachable for callers that pass their own arguments.
+func (m *MermanEngine) runErr(caller, runCtx context.Context, err error, stderr []byte) error {
+	if ctxErr := runCtx.Err(); ctxErr != nil {
+		return classifyRenderErr(caller, m.ctx, ctxErr)
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		sentinel := ErrMermanFailed
+		if exit.ExitCode() == 1 {
+			sentinel = ErrRenderException
+		}
+		return classifyRenderErr(caller, m.ctx, fmt.Errorf("%w: %w", sentinel,
+			&MermanExitError{Bin: m.bin, Code: exit.ExitCode(), Stderr: mermanDiagnostic(stderr)}))
+	}
+	return classifyRenderErr(caller, m.ctx, fmt.Errorf("%w: %s: %w", ErrMermanFailed, m.bin, err))
+}
+
+// mermanWaitDelay bounds how long a killed render may keep this call waiting on
+// its output pipes. See the use in run.
+const mermanWaitDelay = 5 * time.Second
+
+// maxDiagnosticBytes caps how much of merman's stderr is carried in an error.
+// A diagram with hundreds of diagnostics would otherwise produce an error string
+// too long to log.
+const maxDiagnosticBytes = 4096
+
+func mermanDiagnostic(stderr []byte) string {
+	text := strings.TrimSpace(string(stderr))
+	if text == "" {
+		return "no diagnostics on stderr"
+	}
+	if len(text) > maxDiagnosticBytes {
+		text = text[:maxDiagnosticBytes] + "... (truncated)"
+	}
+	return text
+}
+
+// boxModelFor describes a w x h box at the origin, the shape chrome's
+// DOM.getBoxModel returns for a diagram with no offset or spacing around it.
+func boxModelFor(w, h float64) *BoxModel {
+	quad := dom.Quad{0, 0, w, 0, w, h, 0, h}
+	return &dom.BoxModel{
+		Content: quad,
+		Padding: quad,
+		Border:  quad,
+		Margin:  quad,
+		Width:   int64(math.Round(w)),
+		Height:  int64(math.Round(h)),
+	}
+}
+
+// bundleSource embeds the diagram source in the SVG's <desc>, as WithBundle does
+// under the chrome backend by way of the DOM. There is no DOM here, so the
+// element is spliced in after the root start tag, which is enough: <desc> is
+// valid as the first child of <svg> and the source is XML-escaped on the way in.
+func bundleSource(svg, content string) (string, error) {
+	open := strings.Index(svg, "<svg")
+	if open < 0 {
+		return "", fmt.Errorf("%w: rendered output has no <svg> element to bundle the source into", ErrMermanFailed)
+	}
+	end, selfClosing := endOfStartTag(svg[open:])
+	if end < 0 {
+		return "", fmt.Errorf("%w: rendered output has an unterminated <svg> start tag", ErrMermanFailed)
+	}
+	end += open
+
+	var desc bytes.Buffer
+	desc.WriteString("<desc>")
+	if err := xml.EscapeText(&desc, []byte(content)); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrFailedEncoding, err)
+	}
+	desc.WriteString("</desc>")
+
+	var out strings.Builder
+	out.Grow(len(svg) + desc.Len() + len("</svg>"))
+	if selfClosing {
+		// <svg .../> has nowhere to put a child, so give it a body to hold one.
+		out.WriteString(svg[:end-1])
+		out.WriteString(">")
+		out.WriteString(desc.String())
+		out.WriteString("</svg>")
+		out.WriteString(svg[end+1:])
+		return out.String(), nil
+	}
+	out.WriteString(svg[:end+1])
+	out.WriteString(desc.String())
+	out.WriteString(svg[end+1:])
+	return out.String(), nil
+}
+
+// endOfStartTag returns the index of the '>' closing the start tag that s begins
+// with, ignoring any '>' inside a quoted attribute value, and whether the tag is
+// self-closing. It returns -1 if the tag is never closed.
+func endOfStartTag(s string) (index int, selfClosing bool) {
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == '>':
+			return i, i > 0 && s[i-1] == '/'
+		}
+	}
+	return -1, false
+}

--- a/merman_test.go
+++ b/merman_test.go
@@ -1,0 +1,907 @@
+package mermaid_go
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// defaultFakeCapabilities mirrors the shape of `merman-cli capabilities --json`
+// for a fully featured build.
+const defaultFakeCapabilities = `{
+  "schema_version": 1,
+  "cli_contract_version": 1,
+  "package": {"name": "merman-cli", "version": "0.7.0"},
+  "compatibility": {"mermaid": "11.16.0", "mmdc": "11.16.0"},
+  "commands": ["render", "batch", "capabilities"],
+  "capabilities": [{"id": "svg"}, {"id": "png"}, {"id": "pdf"}]
+}`
+
+// fakeMerman is a stand-in for the merman binary: a script that answers the
+// capability probe from a canned document and runs the given shell body for a
+// render, recording what it was invoked with. It keeps the tests honest about
+// the command line and the stdin/stdout contract without requiring a Rust
+// toolchain to build the real thing; TestMermanEngine_Live covers a real binary
+// when one is installed.
+type fakeMerman struct {
+	path      string
+	argsFile  string
+	stdinFile string
+}
+
+// legacyMerman, as the capability document, makes the fake behave like merman
+// 0.7.0: no `capabilities` command at all, only --version.
+const legacyMerman = ""
+
+func newFakeMerman(t *testing.T, capabilities, render string) *fakeMerman {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake merman binary is a shell script")
+	}
+	dir := t.TempDir()
+	fake := &fakeMerman{
+		path:      filepath.Join(dir, "merman-cli"),
+		argsFile:  filepath.Join(dir, "args"),
+		stdinFile: filepath.Join(dir, "stdin"),
+	}
+	capabilityBranch := fmt.Sprintf("cat <<'MERMAN_CAPABILITIES'\n%s\nMERMAN_CAPABILITIES\nexit 0", capabilities)
+	if capabilities == legacyMerman {
+		capabilityBranch = "echo \"error: unrecognized subcommand 'capabilities'\" >&2\nexit 2"
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1" in
+capabilities)
+%s
+;;
+--version)
+echo "merman-cli 0.7.0"
+exit 0
+;;
+esac
+printf '%%s\n' "$@" > %q
+cat > %q
+%s
+`, capabilityBranch, fake.argsFile, fake.stdinFile, render)
+	if err := os.WriteFile(fake.path, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing the fake merman binary: %v", err)
+	}
+	return fake
+}
+
+// engine builds an engine on the fake binary, failing the test if it will not
+// start.
+func (f *fakeMerman) engine(t *testing.T, opts ...MermanOption) *MermanEngine {
+	t.Helper()
+	opts = append([]MermanOption{WithMermanBinary(f.path)}, opts...)
+	engine, err := NewMermanEngine(context.Background(), opts...)
+	if err != nil {
+		t.Fatalf("NewMermanEngine() error = %v", err)
+	}
+	t.Cleanup(engine.Cancel)
+	return engine
+}
+
+func (f *fakeMerman) args(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(f.argsFile)
+	if err != nil {
+		t.Fatalf("reading the recorded arguments: %v", err)
+	}
+	return strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+}
+
+func (f *fakeMerman) stdin(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(f.stdinFile)
+	if err != nil {
+		t.Fatalf("reading the recorded stdin: %v", err)
+	}
+	return string(data)
+}
+
+// containsArgs reports whether want appears as a run of consecutive arguments,
+// so a test asserts a flag and its value arrived together rather than merely
+// both being somewhere on the command line.
+func containsArgs(args []string, want ...string) bool {
+	for i := 0; i+len(want) <= len(args); i++ {
+		if slices.Equal(args[i:i+len(want)], want) {
+			return true
+		}
+	}
+	return false
+}
+
+// writePNG renders a w x h image to a file, so the fake binary has something
+// genuinely decodable to hand back.
+func writePNG(t *testing.T, w, h int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "diagram.png")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("creating the png: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	if err := png.Encode(file, image.NewRGBA(image.Rect(0, 0, w, h))); err != nil {
+		t.Fatalf("encoding the png: %v", err)
+	}
+	return path
+}
+
+// writeConfig writes a mermaid configuration file for WithMermanConfigFile,
+// which NewMermanEngine now reads rather than trusting.
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mermaid.json")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("writing the config file: %v", err)
+	}
+	return path
+}
+
+const fakeSVG = `<svg id="mermaid" width="100" height="50"><g/></svg>`
+
+func TestNewMermanEngine(t *testing.T) {
+	t.Run("ReportsAMissingBinary", func(t *testing.T) {
+		_, err := NewMermanEngine(context.Background(), WithMermanBinary(filepath.Join(t.TempDir(), "absent")))
+		if !errors.Is(err, ErrMermanUnavailable) {
+			t.Fatalf("NewMermanEngine() error = %v, want ErrMermanUnavailable", err)
+		}
+	})
+
+	t.Run("ReportsAFailingProbe", func(t *testing.T) {
+		// The probe is the only thing standing between a broken install and a
+		// baffling failure on the first render, so its diagnostics must survive.
+		fake := newFakeMerman(t, "", "")
+		script := "#!/bin/sh\necho 'not a merman binary' >&2\nexit 127\n"
+		if err := os.WriteFile(fake.path, []byte(script), 0o755); err != nil {
+			t.Fatalf("rewriting the fake binary: %v", err)
+		}
+		_, err := NewMermanEngine(context.Background(), WithMermanBinary(fake.path))
+		if !errors.Is(err, ErrMermanUnavailable) {
+			t.Fatalf("NewMermanEngine() error = %v, want ErrMermanUnavailable", err)
+		}
+		if !strings.Contains(err.Error(), "not a merman binary") {
+			t.Errorf("NewMermanEngine() error = %q, want it to carry the binary's stderr", err)
+		}
+	})
+
+	t.Run("RejectsABinaryThatCannotRenderSvg", func(t *testing.T) {
+		fake := newFakeMerman(t, `{"package":{"version":"0.7.0"},"commands":["lint"],"capabilities":[{"id":"analysis"}]}`, "")
+		_, err := NewMermanEngine(context.Background(), WithMermanBinary(fake.path))
+		if !errors.Is(err, ErrMermanCapability) {
+			t.Fatalf("NewMermanEngine() error = %v, want ErrMermanCapability", err)
+		}
+	})
+
+	t.Run("ReportsWhatTheBinaryIs", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "")
+		engine := fake.engine(t)
+		if engine.Version() != "0.7.0" {
+			t.Errorf("Version() = %q, want 0.7.0", engine.Version())
+		}
+		if engine.MermaidVersion() != "11.16.0" {
+			t.Errorf("MermaidVersion() = %q, want 11.16.0", engine.MermaidVersion())
+		}
+		if engine.Binary() != fake.path {
+			t.Errorf("Binary() = %q, want %q", engine.Binary(), fake.path)
+		}
+		if got := engine.Capabilities(); !slices.Equal(got, []string{"pdf", "png", "svg"}) {
+			t.Errorf("Capabilities() = %v, want the probed document's ids, sorted", got)
+		}
+	})
+
+	t.Run("AcceptsAReleaseWithoutTheCapabilitiesCommand", func(t *testing.T) {
+		// merman 0.7.0, the current stable, has no `capabilities` command. It
+		// accepts every argument this package builds, so refusing to start on it
+		// -- or concluding from its silence that it cannot render PNG -- would
+		// lock users out of the only release they can install.
+		fake := newFakeMerman(t, legacyMerman, "cat "+fmt.Sprintf("%q", writePNG(t, 20, 10)))
+		engine := fake.engine(t)
+
+		if engine.Version() != "0.7.0" {
+			t.Errorf("Version() = %q, want the version parsed from --version", engine.Version())
+		}
+		if engine.Capabilities() != nil {
+			t.Errorf("Capabilities() = %v, want nil for a binary that reported none", engine.Capabilities())
+		}
+		if engine.MermaidVersion() != "" {
+			t.Errorf("MermaidVersion() = %q, want empty when the binary does not report one", engine.MermaidVersion())
+		}
+		// PNG must be attempted rather than pre-empted by an absent catalogue.
+		if _, _, err := engine.RenderAsPng("graph TD; A-->B;"); err != nil {
+			t.Fatalf("RenderAsPng() error = %v", err)
+		}
+		if !containsArgs(fake.args(t), "--format", "png") {
+			t.Errorf("arguments %v did not reach merman", fake.args(t))
+		}
+	})
+
+	t.Run("RejectsAnUnusableConfigFile", func(t *testing.T) {
+		// merman exits 1 for a bad config file, the same status an invalid diagram
+		// uses, so without this check every render would fail as
+		// ErrRenderException and blame the diagram for a configuration mistake.
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf '<svg/>'")
+
+		_, err := NewMermanEngine(context.Background(),
+			WithMermanBinary(fake.path), WithMermanConfigFile(filepath.Join(t.TempDir(), "absent.json")))
+		if !errors.Is(err, ErrMermanFailed) {
+			t.Fatalf("NewMermanEngine() with a missing config error = %v, want ErrMermanFailed", err)
+		}
+		if errors.Is(err, ErrRenderException) {
+			t.Errorf("NewMermanEngine() error = %v, should not blame a diagram", err)
+		}
+
+		_, err = NewMermanEngine(context.Background(),
+			WithMermanBinary(fake.path), WithMermanConfigFile(writeConfig(t, "not json")))
+		if !errors.Is(err, ErrMermanFailed) {
+			t.Fatalf("NewMermanEngine() with malformed config error = %v, want ErrMermanFailed", err)
+		}
+	})
+
+	t.Run("RejectsABinaryThatCannotAnswerItsOwnCapabilities", func(t *testing.T) {
+		// Falling back to --version is for releases too old to know the command,
+		// which say so with a usage error. A binary that knows it and fails it is
+		// broken, and starting blind would hide that until the first render.
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf '<svg/>'")
+		script := "#!/bin/sh\n" +
+			"case \"$1\" in\n" +
+			"capabilities) echo 'capability catalogue unreadable' >&2; exit 3 ;;\n" +
+			"--version) echo 'merman-cli 0.9.0'; exit 0 ;;\n" +
+			"esac\nprintf '<svg/>'\n"
+		if err := os.WriteFile(fake.path, []byte(script), 0o755); err != nil {
+			t.Fatalf("rewriting the fake binary: %v", err)
+		}
+
+		_, err := NewMermanEngine(context.Background(), WithMermanBinary(fake.path))
+		if !errors.Is(err, ErrMermanUnavailable) {
+			t.Fatalf("NewMermanEngine() error = %v, want ErrMermanUnavailable", err)
+		}
+		if !strings.Contains(err.Error(), "capabilities") || !strings.Contains(err.Error(), "unreadable") {
+			t.Errorf("NewMermanEngine() error = %q, want the capabilities failure, not the --version fallback", err)
+		}
+	})
+
+	t.Run("ReportsAFailedFallback", func(t *testing.T) {
+		// The other side of the legacy path: the binary rejects `capabilities`
+		// like an old release would, and then cannot answer --version either. The
+		// fallback's own failure is the diagnostic, since the rejection above it
+		// says nothing about whether the binary works.
+		fake := newFakeMerman(t, defaultFakeCapabilities, "")
+		script := "#!/bin/sh\n" +
+			"case \"$1\" in\n" +
+			"capabilities) echo \"error: unrecognized subcommand 'capabilities'\" >&2; exit 2 ;;\n" +
+			"esac\necho 'segmentation fault' >&2\nexit 139\n"
+		if err := os.WriteFile(fake.path, []byte(script), 0o755); err != nil {
+			t.Fatalf("rewriting the fake binary: %v", err)
+		}
+		_, err := NewMermanEngine(context.Background(), WithMermanBinary(fake.path))
+		if !errors.Is(err, ErrMermanUnavailable) {
+			t.Fatalf("NewMermanEngine() error = %v, want ErrMermanUnavailable", err)
+		}
+		if !strings.Contains(err.Error(), "--version") || !strings.Contains(err.Error(), "segmentation fault") {
+			t.Errorf("NewMermanEngine() error = %q, want the --version failure and its diagnostics", err)
+		}
+	})
+}
+
+func TestMermanEngine_Render(t *testing.T) {
+	content := "graph TD; A-->B;"
+
+	t.Run("PipesTheDiagramThroughTheCLI", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf '%s' "+fmt.Sprintf("%q", fakeSVG))
+		engine := fake.engine(t)
+
+		svg, err := engine.Render(content)
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+		if svg != fakeSVG {
+			t.Errorf("Render() = %q, want the binary's stdout verbatim", svg)
+		}
+		if got := fake.stdin(t); got != content {
+			t.Errorf("the binary read %q on stdin, want the diagram source", got)
+		}
+
+		args := fake.args(t)
+		// The payload has to arrive on stdout and the source on stdin, or the
+		// engine would be reading a file merman never wrote.
+		for _, want := range [][]string{{"render", "-"}, {"--output", "-"}, {"--svg-id", DefaultMermanSvgID}} {
+			if !containsArgs(args, want...) {
+				t.Errorf("arguments %v are missing %v", args, want)
+			}
+		}
+	})
+
+	t.Run("PassesTheConfiguredOptions", func(t *testing.T) {
+		config := writeConfig(t, `{"theme":"dark"}`)
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf '<svg/>'")
+		engine := fake.engine(t,
+			WithMermanTheme("dark"),
+			WithMermanConfigFile(config),
+			WithMermanSvgID("diagram"),
+			WithMermanArgs("--resource-profile", "constrained"),
+		)
+		if _, err := engine.Render(content); err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+		args := fake.args(t)
+		for _, want := range [][]string{
+			{"--theme", "dark"},
+			{"--config-file", config},
+			{"--svg-id", "diagram"},
+			{"--resource-profile", "constrained"},
+		} {
+			if !containsArgs(args, want...) {
+				t.Errorf("arguments %v are missing %v", args, want)
+			}
+		}
+	})
+
+	t.Run("BundlesTheSourceIntoTheSvg", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf '%s' "+fmt.Sprintf("%q", fakeSVG))
+		engine := fake.engine(t)
+
+		svg, err := engine.Render("graph TD; A-->B & C;", WithBundle())
+		if err != nil {
+			t.Fatalf("Render(WithBundle()) error = %v", err)
+		}
+		if !strings.Contains(svg, "<desc>graph TD; A--&gt;B &amp; C;</desc>") {
+			t.Errorf("Render(WithBundle()) = %q, want the escaped source in a <desc>", svg)
+		}
+	})
+}
+
+func TestMermanEngine_RenderAsScaledPng(t *testing.T) {
+	image := writePNG(t, 200, 100)
+
+	t.Run("ReturnsTheImageAndItsBox", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "cat "+fmt.Sprintf("%q", image))
+		engine := fake.engine(t)
+
+		data, box, err := engine.RenderAsScaledPng("graph TD; A-->B;", 2.0)
+		if err != nil {
+			t.Fatalf("RenderAsScaledPng() error = %v", err)
+		}
+		if _, err := png.DecodeConfig(bytes.NewReader(data)); err != nil {
+			t.Fatalf("RenderAsScaledPng() returned an undecodable image: %v", err)
+		}
+		// The box model is in CSS pixels, as chrome reports it, so a 2x image of
+		// a 100x50 diagram still measures 100x50.
+		if box.Width != 100 || box.Height != 50 {
+			t.Errorf("RenderAsScaledPng() box = %dx%d, want 100x50", box.Width, box.Height)
+		}
+		if len(box.Content) != 8 || box.Content[4] != 100 || box.Content[5] != 50 {
+			t.Errorf("RenderAsScaledPng() content quad = %v, want the box at the origin", box.Content)
+		}
+		if !containsArgs(fake.args(t), "--format", "png") || !containsArgs(fake.args(t), "--scale", "2") {
+			t.Errorf("arguments %v do not ask for a 2x png", fake.args(t))
+		}
+	})
+
+	t.Run("OmitsTheDefaultScale", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "cat "+fmt.Sprintf("%q", image))
+		engine := fake.engine(t)
+		if _, _, err := engine.RenderAsPng("graph TD; A-->B;"); err != nil {
+			t.Fatalf("RenderAsPng() error = %v", err)
+		}
+		if containsArgs(fake.args(t), "--scale") {
+			t.Errorf("arguments %v pass a scale merman already defaults to", fake.args(t))
+		}
+	})
+
+	t.Run("RejectsWhatItCannotHonour", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "cat "+fmt.Sprintf("%q", image))
+		engine := fake.engine(t)
+
+		if _, _, err := engine.RenderAsPng("graph TD; A-->B;", WithBundle()); !errors.Is(err, ErrUnsupportedOption) {
+			t.Errorf("RenderAsPng(WithBundle()) error = %v, want ErrUnsupportedOption", err)
+		}
+		// NaN and +Inf slip past a bare scale <= 0 check and would reach merman
+		// as "NaN"/"+Inf", coming back as a rejected command line instead.
+		for _, scale := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+			if _, _, err := engine.RenderAsScaledPng("graph TD; A-->B;", scale); !errors.Is(err, ErrUnsupportedOption) {
+				t.Errorf("RenderAsScaledPng(%v) error = %v, want ErrUnsupportedOption", scale, err)
+			}
+		}
+	})
+
+	t.Run("ReportsABinaryWithoutPng", func(t *testing.T) {
+		// PNG support is a compile-time feature of the CLI, so this is worth
+		// saying plainly rather than letting merman reject the command line.
+		fake := newFakeMerman(t, `{"package":{"version":"0.7.0"},"commands":["render"],"capabilities":[{"id":"svg"}]}`, "printf '<svg/>'")
+		engine := fake.engine(t)
+		_, _, err := engine.RenderAsPng("graph TD; A-->B;")
+		if !errors.Is(err, ErrMermanCapability) {
+			t.Errorf("RenderAsPng() error = %v, want ErrMermanCapability", err)
+		}
+	})
+
+	t.Run("RejectsAnUndecodableImage", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf 'not a png'")
+		engine := fake.engine(t)
+		data, box, err := engine.RenderAsPng("graph TD; A-->B;")
+		if !errors.Is(err, ErrMermanFailed) {
+			t.Fatalf("RenderAsPng() error = %v, want ErrMermanFailed", err)
+		}
+		if data != nil || box != nil {
+			t.Errorf("RenderAsPng() returned data=%d bytes, box=%v on failure, want neither", len(data), box)
+		}
+	})
+}
+
+func TestMermanEngine_ErrorClassification(t *testing.T) {
+	t.Run("InvalidDiagramIsAnException", func(t *testing.T) {
+		// merman exits 1 for invalid mermaid, which is the same non-retryable
+		// rejection of the diagram source the chrome backend reports.
+		fake := newFakeMerman(t, defaultFakeCapabilities, "echo 'error: unexpected token' >&2\nexit 1")
+		engine := fake.engine(t)
+
+		_, err := engine.Render("graph TD; A---;")
+		if !errors.Is(err, ErrRenderException) {
+			t.Fatalf("Render() error = %v, want ErrRenderException", err)
+		}
+		if !strings.Contains(err.Error(), "unexpected token") {
+			t.Errorf("Render() error = %q, want merman's diagnostics", err)
+		}
+	})
+
+	t.Run("ARejectedCommandLineIsNotADiagramError", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "echo 'unexpected argument' >&2\nexit 2")
+		engine := fake.engine(t)
+
+		_, err := engine.Render("graph TD; A-->B;")
+		if !errors.Is(err, ErrMermanFailed) {
+			t.Fatalf("Render() error = %v, want ErrMermanFailed", err)
+		}
+		if errors.Is(err, ErrRenderException) {
+			t.Errorf("Render() error = %v, should not blame the diagram", err)
+		}
+	})
+
+	t.Run("TheExitStatusStaysReachable", func(t *testing.T) {
+		// Exit 1 is not exclusively an invalid diagram on every release, so a
+		// caller that needs certainty must be able to read the status itself.
+		fake := newFakeMerman(t, defaultFakeCapabilities, "echo 'configuration file does not exist' >&2\nexit 1")
+		engine := fake.engine(t)
+
+		_, err := engine.Render("graph TD; A-->B;")
+		var exit *MermanExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("Render() error = %v, want a *MermanExitError to be reachable", err)
+		}
+		if exit.Code != 1 || exit.Bin != fake.path {
+			t.Errorf("MermanExitError = %+v, want exit 1 from %s", exit, fake.path)
+		}
+		if !strings.Contains(exit.Stderr, "configuration file") {
+			t.Errorf("MermanExitError.Stderr = %q, want merman's diagnostics", exit.Stderr)
+		}
+	})
+
+	t.Run("SilentFailuresStillSayWhichBinaryFailed", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "exit 3")
+		engine := fake.engine(t)
+
+		_, err := engine.Render("graph TD; A-->B;")
+		if !errors.Is(err, ErrMermanFailed) {
+			t.Fatalf("Render() error = %v, want ErrMermanFailed", err)
+		}
+		if !strings.Contains(err.Error(), fake.path) {
+			t.Errorf("Render() error = %q, want it to name the binary", err)
+		}
+	})
+}
+
+func TestMermanEngine_Timeout(t *testing.T) {
+	// exec, not a plain sleep: the fake is a shell, and a descendant would keep
+	// the output pipes open past the kill.
+	sleeping := func(t *testing.T) *fakeMerman {
+		return newFakeMerman(t, defaultFakeCapabilities, "exec sleep 30")
+	}
+
+	t.Run("EngineTimeout", func(t *testing.T) {
+		engine := sleeping(t).engine(t)
+		engine.SetRenderTimeout(200 * time.Millisecond)
+		if _, err := engine.Render("graph TD; A-->B;"); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("Render() error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+
+	t.Run("PerCallTimeout", func(t *testing.T) {
+		engine := sleeping(t).engine(t)
+		if _, err := engine.Render("graph TD; A-->B;", WithTimeout(200*time.Millisecond)); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("Render(WithTimeout()) error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+
+	t.Run("CallerCancellationReportsItsCause", func(t *testing.T) {
+		engine := sleeping(t).engine(t)
+		reason := errors.New("caller went away")
+		ctx, cancel := context.WithCancelCause(context.Background())
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel(reason)
+		}()
+		if _, err := engine.RenderContext(ctx, "graph TD; A-->B;"); !errors.Is(err, reason) {
+			t.Errorf("RenderContext() error = %v, want it to report the cancellation cause", err)
+		}
+	})
+
+	t.Run("ATimedOutRenderDoesNotSpoilTheEngine", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf '<svg/>'")
+		engine := fake.engine(t)
+		if _, err := engine.Render("graph TD; A-->B;", WithTimeout(time.Nanosecond)); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Render(WithTimeout()) error = %v, want context.DeadlineExceeded", err)
+		}
+		if _, err := engine.Render("graph TD; A-->B;"); err != nil {
+			t.Errorf("Render() after a timeout error = %v", err)
+		}
+	})
+}
+
+func TestMermanEngine_Lifecycle(t *testing.T) {
+	t.Run("CancelClosesTheEngine", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "printf '<svg/>'")
+		engine := fake.engine(t)
+		engine.Cancel()
+
+		if _, err := engine.Render("graph TD; A-->B;"); !errors.Is(err, ErrEngineClosed) {
+			t.Errorf("Render() after Cancel() error = %v, want ErrEngineClosed", err)
+		}
+		if _, _, err := engine.RenderAsPng("graph TD; A-->B;"); !errors.Is(err, ErrEngineClosed) {
+			t.Errorf("RenderAsPng() after Cancel() error = %v, want ErrEngineClosed", err)
+		}
+	})
+
+	t.Run("CancelAbortsARenderInFlight", func(t *testing.T) {
+		fake := newFakeMerman(t, defaultFakeCapabilities, "exec sleep 30")
+		engine := fake.engine(t)
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := engine.Render("graph TD; A-->B;")
+			done <- err
+		}()
+		time.Sleep(200 * time.Millisecond)
+		engine.Cancel()
+
+		select {
+		case err := <-done:
+			if !errors.Is(err, ErrEngineClosed) {
+				t.Errorf("Render() error = %v, want ErrEngineClosed", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("Cancel() did not abort the render in flight")
+		}
+	})
+
+	t.Run("WaitingForASlotIsBoundedByTheCaller", func(t *testing.T) {
+		// The queueing wait is where a server sheds load, so it has to honour
+		// the caller's context even though the render has not started.
+		fake := newFakeMerman(t, defaultFakeCapabilities, "exec sleep 30")
+		engine := fake.engine(t, WithMermanConcurrency(1))
+
+		go func() { _, _ = engine.Render("graph TD; A-->B;") }()
+		time.Sleep(200 * time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		start := time.Now()
+		if _, err := engine.RenderContext(ctx, "graph TD; A-->B;"); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("RenderContext() error = %v, want context.DeadlineExceeded", err)
+		}
+		if waited := time.Since(start); waited > 5*time.Second {
+			t.Errorf("RenderContext() waited %v for a slot, want it to give up with its context", waited)
+		}
+	})
+}
+
+func TestBundleSource(t *testing.T) {
+	cases := []struct {
+		name, svg, want string
+		wantErr         bool
+	}{
+		{
+			name: "PlainRoot",
+			svg:  `<svg id="mermaid"><g/></svg>`,
+			want: `<svg id="mermaid"><desc>a-&gt;b</desc><g/></svg>`,
+		},
+		{
+			name: "AttributeContainingAngleBrackets",
+			// A '>' inside an attribute value must not be mistaken for the end
+			// of the start tag, or the <desc> lands inside the attribute.
+			svg:  `<svg data-note="a > b"><g/></svg>`,
+			want: `<svg data-note="a > b"><desc>a-&gt;b</desc><g/></svg>`,
+		},
+		{
+			name: "XMLPrologue",
+			svg:  `<?xml version="1.0"?><svg><g/></svg>`,
+			want: `<?xml version="1.0"?><svg><desc>a-&gt;b</desc><g/></svg>`,
+		},
+		{
+			name: "SelfClosingRoot",
+			svg:  `<svg width="10"/>`,
+			want: `<svg width="10"><desc>a-&gt;b</desc></svg>`,
+		},
+		{
+			// XML allows space before the '/' but not between '/' and '>'
+			// (EmptyElemTag ::= '<' Name (S Attribute)* S? '/>'), so looking at
+			// the character before '>' is enough to recognise every valid form.
+			name: "SelfClosingRootWithSpace",
+			svg:  `<svg width="10" />`,
+			want: `<svg width="10" ><desc>a-&gt;b</desc></svg>`,
+		},
+		{
+			name: "SelfClosingRootAcrossLines",
+			svg:  "<svg width=\"10\"\n/>",
+			want: "<svg width=\"10\"\n><desc>a-&gt;b</desc></svg>",
+		},
+		{name: "NotAnSvg", svg: "kaboom", wantErr: true},
+		{name: "UnterminatedStartTag", svg: `<svg id="mermaid"`, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := bundleSource(tc.svg, "a->b")
+			if tc.wantErr {
+				if !errors.Is(err, ErrMermanFailed) {
+					t.Fatalf("bundleSource() error = %v, want ErrMermanFailed", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("bundleSource() error = %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("bundleSource() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// liveMermanEngine builds an engine on a real merman binary, skipping when none
+// is installed. The fake binary keeps this package honest about its own side of
+// the contract; only a real binary proves the command line it builds is one
+// merman accepts, which is why CI installs it.
+func liveMermanEngine(t *testing.T, opts ...MermanOption) *MermanEngine {
+	t.Helper()
+	if _, err := lookMerman(""); err != nil {
+		t.Skipf("no merman binary on PATH: %v", err)
+	}
+	engine, err := NewMermanEngine(context.Background(), opts...)
+	if err != nil {
+		t.Fatalf("NewMermanEngine() error = %v", err)
+	}
+	t.Cleanup(engine.Cancel)
+	return engine
+}
+
+func TestMermanEngine_LiveRender(t *testing.T) {
+	engine := liveMermanEngine(t)
+	t.Logf("merman %s (mermaid %q, capabilities %v) at %s",
+		engine.Version(), engine.MermaidVersion(), engine.Capabilities(), engine.Binary())
+
+	// The families the chrome backend is tested against, so the two backends are
+	// held to the same diagrams rather than to a merman-shaped subset.
+	diagrams := map[string]string{
+		"Flowchart": `graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;`,
+		"Sequence": `sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Healthcheck
+    John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!`,
+		"Gantt": `gantt
+dateFormat  YYYY-MM-DD
+title Adding GANTT diagram to mermaid
+section A section
+Completed task            :done,    des1, 2014-01-06,2014-01-08
+Active task               :active,  des2, 2014-01-09, 3d`,
+		"Class": `classDiagram
+Class01 <|-- AveryLongClass : Cool
+Class03 *-- Class04
+Class07 : equals()
+Class01 : size()`,
+		"GitGraph": `gitGraph
+       commit
+       branch develop
+       commit
+       checkout main
+       merge develop`,
+		"Entity": `erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains`,
+		"Journey": `journey
+    title My working day
+    section Go to work
+      Make tea: 5: Me
+      Do work: 1: Me, Cat`,
+		"State": `stateDiagram-v2
+    [*] --> Still
+    Still --> Moving
+    Moving --> [*]`,
+		"Pie": `pie title Pets
+    "Dogs" : 386
+    "Cats" : 85`,
+		"QuotedLabels": `graph TD;
+    A-->B['name'];
+    A-->C["pic"];`,
+		"MarkdownLabel": "graph TD;\n\tA-->B[\"`Hello World`\"];\n\tB-->C;",
+	}
+	for name, content := range diagrams {
+		t.Run(name, func(t *testing.T) {
+			svg, err := engine.Render(content)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+			if !strings.HasPrefix(svg, "<svg") || !strings.HasSuffix(strings.TrimSpace(svg), "</svg>") {
+				t.Errorf("Render() = %.120q..., want a complete svg document", svg)
+			}
+		})
+	}
+
+	t.Run("RootIDMatchesTheChromeBackend", func(t *testing.T) {
+		// merman's own default is id="merman"; the engine asks for mermaid.js's
+		// id so a diagram styled against one backend works under the other.
+		svg, err := engine.Render("graph TD; A-->B;")
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+		if !strings.Contains(svg, `id="`+DefaultMermanSvgID+`"`) {
+			t.Errorf("Render() = %.120q..., want the root svg to carry id=%q", svg, DefaultMermanSvgID)
+		}
+	})
+
+	t.Run("BundleDiagram", func(t *testing.T) {
+		svg, err := engine.Render("graph TD; A-->B;", WithBundle())
+		if err != nil {
+			t.Fatalf("Render(WithBundle()) error = %v", err)
+		}
+		// The same assertion the chrome backend's BundleDiagram subtest makes.
+		if !strings.Contains(svg, "<desc>graph TD; A--&gt;B;</desc>") {
+			t.Errorf("Render(WithBundle()) = %.200q..., want the escaped source in a <desc>", svg)
+		}
+	})
+
+	t.Run("InvalidSyntax", func(t *testing.T) {
+		// merman exits 1 for a parse error, which must arrive as the same
+		// non-retryable error the chrome backend reports for a bad diagram.
+		_, err := engine.Render("graph TD; A---;")
+		if !errors.Is(err, ErrRenderException) {
+			t.Fatalf("Render() error = %v, want ErrRenderException", err)
+		}
+		if errors.Is(err, ErrMermanFailed) {
+			t.Errorf("Render() error = %v, should blame the diagram rather than the binary", err)
+		}
+		if !strings.Contains(err.Error(), "parse error") {
+			t.Errorf("Render() error = %v, want merman's own diagnostic", err)
+		}
+	})
+
+	t.Run("Options", func(t *testing.T) {
+		themed := liveMermanEngine(t, WithMermanTheme("dark"), WithMermanSvgID("diagram"))
+		svg, err := themed.Render("graph TD; A-->B;")
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+		if !strings.Contains(svg, `id="diagram"`) {
+			t.Errorf("Render() = %.120q..., want WithMermanSvgID honoured", svg)
+		}
+	})
+
+	t.Run("OperationalFailureStaysInspectable", func(t *testing.T) {
+		// WithMermanArgs can reach a failure the diagram is not to blame for -- a
+		// missing configuration file is one, which is why NewMermanEngine
+		// validates the file it owns. Which status merman picks for it is its own
+		// business and has changed across releases: 0.7.0 exits 1, the same as an
+		// invalid diagram, while 0.8 exits 2. That is precisely why the status has
+		// to stay readable rather than be inferred, so assert it is there and
+		// explains itself, not what it is.
+		rogue := liveMermanEngine(t, WithMermanArgs("--config-file", filepath.Join(t.TempDir(), "absent.json")))
+		_, err := rogue.Render("graph TD; A-->B;")
+		var exit *MermanExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("Render() error = %v, want a *MermanExitError to be reachable", err)
+		}
+		if exit.Code == 0 || exit.Stderr == "" {
+			t.Errorf("MermanExitError = %+v, want a non-zero status with merman's diagnostics", exit)
+		}
+	})
+
+	t.Run("ConcurrentRenders", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for i := range 5 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				svg, err := engine.Render("graph TD; A-->B;")
+				if err != nil {
+					t.Errorf("concurrent Render() %d error = %v", i, err)
+					return
+				}
+				if !strings.HasPrefix(svg, "<svg") {
+					t.Errorf("concurrent Render() %d returned an invalid svg", i)
+				}
+			}()
+		}
+		wg.Wait()
+	})
+
+	t.Run("ATimedOutRenderDoesNotSpoilTheEngine", func(t *testing.T) {
+		if _, err := engine.Render("graph TD; A-->B;", WithTimeout(time.Nanosecond)); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Render(WithTimeout()) error = %v, want context.DeadlineExceeded", err)
+		}
+		if _, err := engine.Render("graph TD; A-->B;"); err != nil {
+			t.Errorf("Render() after a timeout error = %v", err)
+		}
+	})
+}
+
+func TestMermanEngine_LivePng(t *testing.T) {
+	engine := liveMermanEngine(t)
+	if caps := engine.Capabilities(); caps != nil && !slices.Contains(caps, "png") {
+		t.Skip("the installed merman was built without png output")
+	}
+	content := "graph TD; A-->B;"
+
+	unscaled, box, err := engine.RenderAsPng(content)
+	if err != nil {
+		t.Fatalf("RenderAsPng() error = %v", err)
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(unscaled))
+	if err != nil {
+		t.Fatalf("RenderAsPng() returned an undecodable image: %v", err)
+	}
+	if int64(config.Width) != box.Width || int64(config.Height) != box.Height {
+		t.Errorf("RenderAsPng() image is %dx%d but the box says %dx%d", config.Width, config.Height, box.Width, box.Height)
+	}
+
+	t.Run("ScaleGrowsTheImageNotTheBox", func(t *testing.T) {
+		// The box model is in CSS pixels, as chrome reports it, so it must not
+		// move with the scale even though the image does.
+		scaled, scaledBox, err := engine.RenderAsScaledPng(content, 2.0)
+		if err != nil {
+			t.Fatalf("RenderAsScaledPng(2.0) error = %v", err)
+		}
+		scaledConfig, err := png.DecodeConfig(bytes.NewReader(scaled))
+		if err != nil {
+			t.Fatalf("RenderAsScaledPng(2.0) returned an undecodable image: %v", err)
+		}
+		if scaledConfig.Width != 2*config.Width || scaledConfig.Height != 2*config.Height {
+			t.Errorf("RenderAsScaledPng(2.0) image is %dx%d, want twice %dx%d",
+				scaledConfig.Width, scaledConfig.Height, config.Width, config.Height)
+		}
+		if scaledBox.Width != box.Width || scaledBox.Height != box.Height {
+			t.Errorf("RenderAsScaledPng(2.0) box = %dx%d, want the unscaled %dx%d",
+				scaledBox.Width, scaledBox.Height, box.Width, box.Height)
+		}
+	})
+
+	t.Run("InvalidSyntaxPng", func(t *testing.T) {
+		data, box, err := engine.RenderAsPng("graph TD; A---;")
+		if !errors.Is(err, ErrRenderException) {
+			t.Fatalf("RenderAsPng() error = %v, want ErrRenderException", err)
+		}
+		if data != nil || box != nil {
+			t.Errorf("RenderAsPng() returned data=%d bytes, box=%v on failure, want neither", len(data), box)
+		}
+	})
+}

--- a/renderer.go
+++ b/renderer.go
@@ -1,0 +1,100 @@
+package mermaid_go
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Renderer is the behaviour shared by the render backends, so a program can
+// choose between them at startup and pass one around without caring which it
+// got. [RenderEngine] drives a headless chrome through chromedp; [MermanEngine]
+// shells out to the merman CLI, which parses and lays diagrams out natively and
+// therefore needs no browser at all.
+//
+// Backend-specific facilities stay off the interface: chrome's crash reporting
+// ([RenderEngine.CrashError], [RenderEngine.SetTargetCrashedHandler]) has no
+// merman equivalent, and merman's capability report has no chrome equivalent.
+type Renderer interface {
+	Render(content string, opts ...RenderOption) (string, error)
+	RenderContext(ctx context.Context, content string, opts ...RenderOption) (string, error)
+	RenderAsPng(content string, opts ...RenderOption) ([]byte, *BoxModel, error)
+	RenderAsPngContext(ctx context.Context, content string, opts ...RenderOption) ([]byte, *BoxModel, error)
+	RenderAsScaledPng(content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error)
+	RenderAsScaledPngContext(ctx context.Context, content string, scale float64, opts ...RenderOption) ([]byte, *BoxModel, error)
+	SetRenderTimeout(d time.Duration)
+	Cancel()
+}
+
+var (
+	_ Renderer = (*RenderEngine)(nil)
+	_ Renderer = (*MermanEngine)(nil)
+)
+
+// waitForSlot waits for a render's turn, giving up if the caller's context is
+// cancelled or the engine is closed. Without it a caller could sit behind an
+// unbounded queue of other renders with no way out, because the per-render
+// deadline only starts once a render actually begins. The error is returned
+// unclassified; callers pass it through their own classifyRenderErr.
+func waitForSlot(ctx, engineCtx context.Context, sem chan struct{}) (release func(), err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	select {
+	case sem <- struct{}{}:
+		return func() { <-sem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-engineCtx.Done():
+		return nil, engineCtx.Err()
+	}
+}
+
+// classifyRenderErr labels a failed render with the lifecycle facts a caller
+// cannot recover from the error alone. When the caller's context is what ended
+// it, the derived context reports a bare Canceled; the caller's own cause says
+// why, so prefer it. And say so when the engine itself is what ended the render,
+// since that calls for building a new engine rather than simply retrying.
+func classifyRenderErr(caller, engineCtx context.Context, err error) error {
+	if errors.Is(err, context.Canceled) {
+		if cause := context.Cause(caller); cause != nil {
+			err = cause
+		}
+	}
+	if engineCtx.Err() != nil {
+		err = fmt.Errorf("%w: %w", ErrEngineClosed, err)
+	}
+	return err
+}
+
+// deriveRenderContext derives the context for one render. It is rooted at the
+// engine context, so cancelling the engine aborts renders in flight, while the
+// caller's context contributes its deadline and its cancellation but not its
+// values.
+func deriveRenderContext(engineCtx, caller context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	// Honour whichever of the two deadlines lands first, so a caller asking for
+	// less than the engine's timeout gets a truthful DeadlineExceeded rather
+	// than the bare Canceled that propagation alone would produce.
+	deadline, hasDeadline := caller.Deadline()
+	switch {
+	case timeout > 0 && hasDeadline && time.Now().Add(timeout).Before(deadline):
+		ctx, cancel = context.WithTimeout(engineCtx, timeout)
+	case hasDeadline:
+		ctx, cancel = context.WithDeadline(engineCtx, deadline)
+	case timeout > 0:
+		ctx, cancel = context.WithTimeout(engineCtx, timeout)
+	default:
+		ctx, cancel = context.WithCancel(engineCtx)
+	}
+
+	stop := context.AfterFunc(caller, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}


### PR DESCRIPTION
Refs #76.

Adds merman as an **opt-in second backend** rather than replacing chromedp. `NewRenderEngine` stays the default and the reference implementation — merman is a separate implementation of Mermaid pinned to its own baseline, not `mermaid.js` itself, so its SVG is not byte-identical.

```go
re, err := mermaid_go.NewMermanEngine(context.Background())
svg, err := re.Render("graph TD; A-->B;", mermaid_go.WithBundle())
```

Both engines satisfy a new `Renderer` interface (`Render`, `RenderAsPng`, `RenderAsScaledPng`, their `Context` variants, `SetRenderTimeout`, `Cancel`), so a program can choose a backend at startup and pass it around. Backend-specific facilities stay off the interface: Chrome's crash reporting has no merman equivalent, and merman's `Version`/`MermaidVersion`/`Binary`/`Capabilities` has no Chrome equivalent.

## Parity

Kept wherever it cost nothing, so switching backends is not a rewrite:

- `WithBundle()` puts the source in the SVG's `<desc>` — spliced in with a quote-aware start-tag scan, since there is no DOM here — and is still `ErrUnsupportedOption` on a PNG.
- The root `<svg>` gets `id="mermaid"`, matching `mermaid.js` (merman's own default is `id="merman"`).
- An invalid diagram is the same non-retryable `ErrRenderException`; `SetRenderTimeout`/`WithTimeout`, cancellation causes and `ErrEngineClosed` behave as they do on Chrome.

## Deliberate differences

- **Concurrency.** Each render is its own process, so renders run in parallel up to `WithMermanConcurrency` (default `GOMAXPROCS`) rather than being serialised onto one tab. The wait for a slot is still covered by the caller's context.
- **PNG box model.** Derived from the image — width/height only, in CSS pixels as Chrome reports them (pixels ÷ scale) — because merman reports no layout box. Verified against a real binary: 86×174 at 1×, 172×348 at 2×, box unchanged.
- **No `statements`.** There is no JavaScript context, so `WithMermanTheme` / `WithMermanConfigFile` / `WithMermanArgs` stand in.
- Only SVG and PNG are exposed, not merman's PDF/JPEG/ASCII.

## Failures the CLI cannot cleanly signal

merman's exit statuses do not partition failures the same way across releases: **0.7.0 exits 1 for a bad configuration file — the status an invalid diagram also uses — while 0.8 moved that to 2**, leaving 1 to mean invalid content alone. Mapping the status straight onto a sentinel would therefore blame the diagram for a configuration mistake on the current stable release. Three things address that:

- `NewMermanEngine` reads the file given to `WithMermanConfigFile` and checks it parses as JSON, so the one operational exit-1 this package can provoke fails once, at construction, instead of once per render.
- A `*MermanExitError` (`Bin`, `Code`, `Stderr`) is wrapped into every process failure and reachable with `errors.As`, so a caller using `WithMermanArgs` can read the status instead of trusting the sentinel.
- The shared `ErrRenderException` no longer describes itself as a JavaScript exception. It now reads *"render rejected the diagram source"*, with each backend's detail documented as the way to get at what actually happened: `*runtime.ExceptionDetails` on Chrome, `*MermanExitError` on merman.

## Version compatibility

Works with both CLI generations, and the tests run against both locally:

- **0.8.0-alpha.6** (Mermaid baseline 11.17.2) answers `capabilities --json`, so `Capabilities()` and `MermaidVersion()` are populated and the PNG pre-check is live.
- **0.7.0**, the current stable, predates that command. The probe falls back to `--version` and records the catalogue as *unknown rather than empty*, so `RenderAsPng` attempts the render and lets merman answer instead of refusing on a promise the binary never made.

The fallback is deliberately narrow: only a usage error (exit 2, how a release rejects a command it does not know) counts. A binary that understands `capabilities` and fails it — a broken or incompatible install — is reported rather than started blind. CI proved that on the first bump attempt, where an unrunnable binary surfaced as `GLIBC_2.38 not found` instead of a confusing fallback error.

Every argument this package builds (`render - --output - --quiet --svg-id --theme --config-file --format --scale`) was verified accepted by both released binaries.

## Tests and CI

- Most merman tests drive a scripted stand-in binary, so they need nothing installed: they pin the argument vector, the stdin/stdout contract, error classification, timeouts, cancellation and slot-waiting.
- `TestMermanEngine_LiveRender` / `TestMermanEngine_LivePng` run against a real binary, covering the same eleven diagram families the Chrome backend is tested against, plus bundling, PNG scaling and invalid syntax. They skip when no merman is on `PATH` — but a merman that is present and cannot run *fails*, since silence there would look like coverage.
- `ci-unit-tests` installs a checksum-verified `merman-cli` **0.8.0-alpha.6**, so the probe's real path is exercised against a real binary rather than only the fake. That build needs glibc 2.38, hence `ubuntu-latest`; the newer image in turn restricts the unprivileged user namespaces Chrome's sandbox needs, hence the one-line sysctl step.

`go test ./...` passes against both merman releases with Chrome installed; `golangci-lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
